### PR TITLE
Working whitelist, improved member form 

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -31,6 +31,7 @@ from .models import (
     Organization,
     Campaign,
     Membership,
+    User,
 )
 from .choices import (
     RACE_CHOICES,
@@ -201,11 +202,20 @@ class CampaignForm(ModelForm):
 
 
 class MemberForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(MemberForm, self).__init__(*args, **kwargs)
+        self.fields["member"].widget.attrs.update({"class": "form-control"})
+        self.fields["is_org_moderator"].widget.attrs.update(
+            {"class": "form-control"}
+        )
+        self.fields["is_org_admin"].widget.attrs.update(
+            {"class": "form-control"}
+        )
+
     class Meta:
         model = Membership
         fields = [
             "member",
             "is_org_admin",
             "is_org_moderator",
-            "is_whitelisted",
         ]

--- a/main/models.py
+++ b/main/models.py
@@ -40,12 +40,26 @@ from .utils import generate_unique_slug
 class User(AbstractUser):
     # TODO: Add a language variable for each user
     def is_org_admin(self, org_id):
-        group = "admins_" + str(org_id)
-        return self.groups.filter(name=group).exists()
+        if Membership.objects.filter(
+            member=self, organization__pk=org_id, is_org_admin=True
+        ):
+            return True
+        else:
+            return False
 
     def is_org_moderator(self, org_id):
-        group = "mods_" + str(org_id)
-        return self.groups.filter(name=group).exists()
+        if Membership.objects.filter(
+            member=self, organization__pk=org_id, is_org_moderator=True
+        ):
+            return True
+        else:
+            return False
+
+    def is_member(self, org_id):
+        if Membership.objects.filter(member=self, organization__pk=org_id):
+            return True
+        else:
+            return False
 
 
 # ******************************************************************************#

--- a/main/templates/main/dashboard/partners/thanks.html
+++ b/main/templates/main/dashboard/partners/thanks.html
@@ -17,7 +17,7 @@
                         {% endif %}
                     </h5>
                     <p class="text-center">We are excited to work with you to create high-quality maps of communities of interest.</p>
-                    <div class="text-center"> <a class="btn btn-primary btn-canvas font-weight-light text-uppercase" href="{% url 'main:home_org' view.kwargs.slug  view.kwargs.pk %}" role="button"><small>organization homepage</small></a>
+                    <div class="text-center"> <a class="btn btn-primary btn-canvas font-weight-light text-uppercase" href="{% url 'main:home_org' view.kwargs.slug  view.kwargs.pk %}" role="button"><small>organization dashboard</small></a>
                     </div>
                 </div>
             </div>

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -463,8 +463,7 @@ class EntryView(LoginRequiredMixin, View):
                         )
                         member.save()
 
-                        # delete from whitelist now that we have added user as a member
-                        whitelist_entry.delete()
+                        # approve this entry
                         entryForm.admin_approved = True
 
             entryForm.save()


### PR DESCRIPTION
Whitelist fixes:

- When user uploads submission with an org selected, checks if they are a member of that org. If so, sets the admin_approved field of the entry to true. 

- If they are not a member, checks if they are on the whitelist. If so, adds them as a member and deletes whitelist entry.

Org member form fixes:

- Stops creating duplicate members when on the member creation form (local link to creation form: http://127.0.0.1:8000/dashboard/partners/[org_slug-id]/members/create)

Resolves #41 