### PR TITLE
a collection of small changes to visuals

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -240,8 +240,8 @@ document.addEventListener(
 var map = new mapboxgl.Map({
   container: "map", // container id
   style: "mapbox://styles/mapbox/streets-v11", //hosted style id
-  center: [-74.65545, 40.341701], // starting position - Princeton, NJ :)
-  zoom: 9, // starting zoom
+  center: [-96.7026, 40.8136], // starting position - Lincoln, NE :)
+  zoom: 3, // starting zoom -- higher is closer
 });
 
 var layerList = document.getElementById("menu");
@@ -510,7 +510,7 @@ class CensusBlocksControl {
           map.setPaintProperty(clickedLayer, "fill-opacity", [
             "*",
             ["get", "POP10"],
-            0.001,
+            0.0005,
           ]);
         }
       }
@@ -586,8 +586,8 @@ function newCensusShading(state) {
       visibility: "visible",
     },
     paint: {
-      "fill-outline-color": "rgb(71, 93, 204)",
-      "fill-color": "rgb(71, 93, 204)",
+      "fill-outline-color": "rgb(0, 0, 0)",
+      "fill-color": "rgb(0, 0, 0)",
       "fill-opacity": 0,
     },
   });
@@ -607,8 +607,8 @@ function newHighlightLayer(state) {
   });
 }
 
-// [WIP] function to add the neighbor layers for the filter that queries 
-// included census blocks 
+// [WIP] function to add the neighbor layers for the filter that queries
+// included census blocks
 function addNeighborLayersFilter() {
   for (let i = 0; 0 < neighbors.length; i++) {
     if (map.getLayer(neighbors[i] + "-blocks-highlighted")) {
@@ -623,12 +623,12 @@ function addNeighborLayersFilter() {
 function addStateNeighborLayers(new_neighbors, new_state) {
   // remove the old state layer and add the new state layer
   if (map.getLayer(state + "-blocks-highlighted")) map.removeLayer(state + "-blocks-highlighted");
-  newHighlightLayer(new_state);	
+  newHighlightLayer(new_state);
   // iterate through all states in the new_neighbors
   // if includes, don't add
   // delete from old neighbors
   // remove layers in the old neighbors list
-  for (let i = 0; i < new_neighbors.length; i++) {	
+  for (let i = 0; i < new_neighbors.length; i++) {
     if (!map.getLayer(new_neighbors[i] + "-blocks-highlighted")) {
       newHighlightLayer(new_neighbors[i]);
     } else {

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -433,7 +433,7 @@ map.on("load", function () {
         "line-cap": "round",
       },
       paint: {
-        "line-color": "rgba(110, 178, 181,0.3)",
+        "line-color": "rgba(0, 0, 0,0.3)",
         "line-width": 2,
       },
     });

--- a/main/static/main/js/partner_map.js
+++ b/main/static/main/js/partner_map.js
@@ -253,11 +253,12 @@ var PAINT_VALUES = {
 /*------------------------------------------------------------------------*/
 /* JS file from mapbox site -- display a polygon */
 /* https://docs.mapbox.com/mapbox-gl-js/example/geojson-polygon/ */
+console.log(organization)
 var map = new mapboxgl.Map({
   container: "map", // container id
   style: "mapbox://styles/mapbox/streets-v11", //color of the map -- dark-v10 or light-v9
-  center: [-74.65545, 40.341701], // starting position - Princeton, NJ :)
-  zoom: 10, // starting zoom -- higher is closer
+  center: [-96.7026, 40.8136], // starting position - Princeton, NJ :)
+  zoom: 3, // starting zoom -- higher is closer
 });
 
 // geocoder used for a search bar -- within the map itself
@@ -296,12 +297,13 @@ function newCensusLayer(state, firstSymbolId) {
       type: "line",
       source: state + "-census",
       "source-layer": state + "census",
+      minzoom: 9,
       layout: {
         visibility: "none",
       },
       paint: {
-        "line-color": "rgba(106,137,204,0.7)",
-        "line-width": 3,
+        "line-color": "rgba(106,137,204,0.3)",
+        "line-width": 2,
       },
     },
     firstSymbolId
@@ -314,6 +316,7 @@ function newUpperLegislatureLayer(state) {
     type: "line",
     source: state + "-upper",
     "source-layer": state + "upper",
+    minzoom: 5,
     layout: {
       visibility: "none",
       "line-join": "round",
@@ -321,7 +324,7 @@ function newUpperLegislatureLayer(state) {
     },
     paint: {
       "line-color": "rgba(106,137,204,0.7)",
-      "line-width": 4,
+      "line-width": 3,
     },
   });
 }
@@ -332,6 +335,7 @@ function newLowerLegislatureLayer(state) {
     type: "line",
     source: state + "-lower",
     "source-layer": state + "lower",
+    minzoom: 5,
     layout: {
       visibility: "none",
       "line-join": "round",
@@ -339,7 +343,7 @@ function newLowerLegislatureLayer(state) {
     },
     paint: {
       "line-color": "rgba(106,137,204,0.7)",
-      "line-width": 4,
+      "line-width": 3,
     },
   });
 }
@@ -390,6 +394,7 @@ map.on("load", function () {
 
   var outputstr = a.replace(/'/g, '"');
   a = JSON.parse(outputstr);
+  var dest = [-74.65545, 40.341701]
 
   for (obj in a) {
     // let catDict = {};
@@ -410,6 +415,7 @@ map.on("load", function () {
     } else {
       final = a[obj];
     }
+    dest = final[0][0]
     // draw the polygon
     map.addLayer({
       id: obj,
@@ -460,7 +466,7 @@ map.on("load", function () {
         "line-cap": "round",
       },
       paint: {
-        "line-color": "rgba(110, 178, 181,0.3)",
+        "line-color": "rgba(0, 0, 0,0.5)",
         "line-width": 2,
       },
     });
@@ -508,7 +514,7 @@ map.on("load", function () {
   });
   // this is necessary so the map "moves" and queries the features above ^^
   map.flyTo({
-    center: [-74.65545, 40.341701],
+    center: dest,
     zoom: 10,
   });
 });
@@ -518,16 +524,16 @@ $("#community-list").on("mouseenter", "li", function () {
   map.setPaintProperty(
     this.id + "line",
     "line-color",
-    "rgba(61, 114, 118, 0.5)"
+    "rgba(0, 0, 0, 0.8)"
   );
-  map.setPaintProperty(this.id + "line", "line-width", 4);
+  map.setPaintProperty(this.id + "line", "line-width", 3);
   map.setPaintProperty(this.id, "fill-color", "rgba(61, 114, 118,0.3)");
 });
 $("#community-list").on("mouseleave", "li", function () {
   map.setPaintProperty(
     this.id + "line",
     "line-color",
-    "rgba(110, 178, 181,0.3)"
+    "rgba(0, 0, 0,0.5)"
   );
   map.setPaintProperty(this.id + "line", "line-width", 2);
   map.setPaintProperty(this.id, "fill-color", "rgba(110, 178, 181,0.15)");

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -68,10 +68,10 @@
                                 <div class="card-header text-header-card">
                                     <strong>
                                       {% if LANGUAGE_CODE == 'en' %}
-                                      1. Please enter the zipcode of your community as a starting point.
+                                      1. Search for a location to begin drawing your community.
                                       {% elif LANGUAGE_CODE == 'es' %}
                                       <!-- Google translate  -->
-                                      Ingrese el código postal de su comunidad como punto de partida.
+                                      1. Busque una ubicación para comenzar a dibujar su comunidad.
                                       {% endif %}
                                     </strong>
                                 </div>

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -30,6 +30,7 @@
   <div class="row row-wide">
     <div>
       <script type="text/javascript">
+        var organization = '{{ organization | escapejs }}'
         var issues = '{{ issues | escapejs }}';
         var a = '{{ entries | escapejs }}';
         var tags = '{{ tags | escapejs }}';
@@ -40,13 +41,8 @@
     <div class="col-md-3 col-wide">
       <nav id='menu'>
         <div class="sidenav">
-          <div class="input-group mb-1">
-            <input class="form-control" id="search-bar" type="search" placeholder="Search communities"
-              onkeyup="searchTags()" aria-label="Search">
-            <div class="input-group-append">
-              <button class="btn btn-outline-primary" type="submit" onclick="searchTags()"><i
-                  class="fa fa-search"></i></button>
-            </div>
+          <div class="my-1">
+            <h4 class="font-weight-light text-center my-2"> {{ organization }} </h4>
           </div>
           <div class="accordion" id="accordionExample">
             <div class="card">

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -42,6 +42,7 @@ class PartnerMap(TemplateView):
     template_name = "main/partners/map.html"
 
     def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
         # dictionary of entry names and reasons
         entry_names = dict()
         entry_reasons = dict()
@@ -86,4 +87,8 @@ class PartnerMap(TemplateView):
             "entries": json.dumps(entryPolyDict),
             "mapbox_key": os.environ.get("DISTR_MAPBOX_KEY"),
         }
+        context["organization"] = Organization.objects.get(
+            slug=self.kwargs["slug"]
+        )
+        print(context)
         return context


### PR DESCRIPTION
- updated wording on entry page (not just zipcode)

- made default map of the entire US (entry page and partner map page)

- changed census block shading to be gray + more transparent, generally (TODO: update to a log scale, maybe?)

- updated partner map page to display org name, in place of spacebar

- partner maps zoom to where communities have been drawn (if no approved communities, remains on map of whole us)

- updated community visualizations to be more distinguishable

- updated census blocks to be less obstructive

- census block and legislature layers now have a minzoom, so they don't clutter the map when zooming out (also reduces lag) (TODO: explain this in tooltip)

![image](https://user-images.githubusercontent.com/41943646/81167308-5c272a80-8fd8-11ea-94fe-8e7e7d63da66.png)
![image](https://user-images.githubusercontent.com/41943646/81167390-7bbe5300-8fd8-11ea-8c49-d1fd1270fa41.png)
![image](https://user-images.githubusercontent.com/41943646/81167551-bcb66780-8fd8-11ea-88e9-339ce7d60edb.png)

