### PR TITLE
bug for polygon too big for michigan - updated area for all states

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -128,6 +128,59 @@ var states = [
   "wy",
 ];
 
+var state_areas = {
+  "ak" : 665384,
+  "al" : 52420,
+  "ar" : 53178,
+  "az" : 113990,
+  "ca" : 163694,
+  "co" : 104093,
+  "ct" : 5543,
+  "dc" : 68,
+  "de" : 2488,
+  "fl" : 65757,
+  "ga" : 59425,
+  "hi" : 10931,
+  "ia" : 56272,
+  "id" : 83568,
+  "il" : 57913,
+  "in" : 36419,
+  "ks" : 82278,
+  "ky" : 40407,
+  "la" : 52378,
+  "ma" : 10554,
+  "md" : 12405,
+  "me" : 35379,
+  "mi" : 96713,
+  "mn" : 86935,
+  "mo" : 69706,
+  "ms" : 48431,
+  "mt" : 147039,
+  "nc" : 53819,
+  "nd" : 70698,
+  "nh" : 9349,
+  "nj" : 8722,
+  "nm" : 121590,
+  "nv" : 110571,
+  "ny" : 54554,
+  "oh" : 44825,
+  "ok" : 69898,
+  "or" : 98378,
+  "pa" : 46054,
+  "ri" : 1544,
+  "sc" : 32020,
+  "sd" : 77115,
+  "tn" : 42144,
+  "tx" : 268596,
+  "ut" : 84896,
+  "va" : 42774,
+  "vt" : 9616,
+  "wa" : 71297,
+  "wi" : 65496,
+  "wv" : 24230,
+  "wy" : 97813,
+}
+
 // dictionary with state neighbors without nebraska since there is
 // no census block data for nebraska
 var state_neighbors = {
@@ -902,9 +955,8 @@ function updateCommunityEntry(e) {
     let area = turf.area(data);
     area = turf.convertArea(area, "meters", "miles");
 
-    // TODO: Need to make sure map does not cross state boundaries??? Maybe this is fine for communities...
-    // Use NJ State Area * 1/2 TODO: need to generalize?
-    let halfStateArea = 4350; // TODO use dictionary lookup based on zipcode
+    // coi is not too big
+    let halfStateArea = state_areas[state]/2;
     if (area > halfStateArea) {
       triggerDrawError(
         "map-area-size-error",


### PR DESCRIPTION
Bug mentioned by Sandy - community too big to draw - because we were using the area for NJ.
Expanded this check for all 50 states.

![image](https://user-images.githubusercontent.com/15281033/81463397-6176a780-9187-11ea-9473-8449c3fd7230.png)

Notice the print statement to the right that pushes the error for the michigan coi and deletes a vertex to take care of it.