### PR TITLE
Fixing Max Zoom Level on Entry Page

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -486,6 +486,7 @@ var map = new mapboxgl.Map({
   style: "mapbox://styles/mapbox/streets-v11", //hosted style id
   center: [-96.7026, 40.8136], // starting position - Lincoln, NE :)
   zoom: 3, // starting zoom -- higher is closer
+  maxZoom: 17, // camelCase. There's no official documentation for this smh :/
 });
 
 var layerList = document.getElementById("menu");
@@ -503,7 +504,6 @@ for (let i = 0; i < inputs.length; i++) {
 var geocoder = new MapboxGeocoder({
   accessToken: mapboxgl.accessToken,
   country: "us",
-  zoom: 10,
   mapboxgl: mapboxgl,
 });
 


### PR DESCRIPTION
Resolves #44 

**To replicate:**

1. Go to last section of the entry. 
2. Search for 08544.
3. Max zoom level is set to 17 now, so people can see small roads if they choose to, but not close enough so it's confusing/ugly.

<img width="918" alt="Screen Shot 2020-05-22 at 14 11 46" src="https://user-images.githubusercontent.com/8714338/82697641-4bf98700-9c37-11ea-87d6-09d1137fbe79.png">
