### PR TITLE
Streamlined Map Editing Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ git push heroku master
 heroku config:set VARIABLE=value
 heroku config:unset VARIABLE
 ```
+
+## Representable Official Colors
+
+Light Blue (Active States/Buttons): <p color="#000000" background-color="#2A94F4">#2A94F4</p>
+Light Green (Active States/Buttons): <p color="#000000" background-color="#00C6A7">#00C6A7</p>
+
+Dark Blue (Inactive States/Buttons): <p color="#000000" background-color="#2176C2">#2176C2</p>
+Dark Green (Inactive States/Buttons): <p color="#000000" background-color="#00B094">#00B094</p>

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -15,6 +15,18 @@ and rules, since this can lead to unintended consequences.
 This means no changing anything like <a>, <li>, <p>, etc.
 */
 
+/* Entry page instructions. */
+.instruction-box {
+  position: absolute;
+  bottom: 40px;
+  left: 10px;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 15px;
+  text-align: center;
+  z-index: 10;
+  display: none;
+}
+
 /* Entry Page: Geocoder Full Width */
 .mapboxgl-ctrl-geocoder {
   width: 100%;

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -23,8 +23,15 @@ This means no changing anything like <a>, <li>, <p>, etc.
   background-color: rgba(255, 255, 255, 0.9);
   padding: 15px;
   text-align: center;
+  border-radius: 10px;
   z-index: 10;
   display: none;
+}
+.red-circle {
+  color: #e74c3c;
+}
+.blue-circle {
+  color: #2a94f4;
 }
 
 /* Entry Page: Geocoder Full Width */

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -21,8 +21,8 @@ This means no changing anything like <a>, <li>, <p>, etc.
   bottom: 40px;
   left: 10px;
   background-color: rgba(255, 255, 255, 0.9);
-  padding: 15px;
-  text-align: center;
+  padding: 10px;
+  text-align: left;
   border-radius: 10px;
   z-index: 10;
   display: none;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -846,7 +846,31 @@ drawControls.appendChild(delete_feature_button);
 delete_feature_button.style.display = "none";
 
 function showMapEditButtons() {
-  var map_edit_button = document.getElementById("");
+  var map_edit_button = document.getElementById("map-edit-button-id");
+  map_edit_button.style.display = "block";
+  var map_clear_map_button = document.getElementById("map-clear-button-id");
+  map_clear_map_button.style.display = "block";
+  var finish_draw_button = document.getElementById(
+    "map-finish-drawing-button-id"
+  );
+  finish_draw_button.style.display = "block";
+}
+
+function hideMapEditButtons() {
+  var map_edit_button = document.getElementById("map-edit-button-id");
+  map_edit_button.style.display = "none";
+  var map_clear_map_button = document.getElementById("map-clear-button-id");
+  map_clear_map_button.style.display = "none";
+  var finish_draw_button = document.getElementById(
+    "map-finish-drawing-button-id"
+  );
+  finish_draw_button.style.display = "none";
+  var map_delete_vertex_button = document.getElementById(
+    "delete-feature-button-id"
+  );
+  if (map_delete_vertex_button != null) {
+    map_delete_vertex_button.style.display = "none";
+  }
 }
 
 function toggleInstructionBox() {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -724,7 +724,7 @@ drawButton[0].innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
 var trashButton = document.getElementsByClassName("mapbox-gl-draw_trash");
 trashButton[0].backgroundImg = "";
 trashButton[0].id = "trash-button";
-trashButton[0].innerHTML = "<i class='fas fa-trash-alt'></i> Undo Polygon";
+trashButton[0].innerHTML = "<i class='fas fa-trash-alt'></i> Delete Selection";
 
 function toggleInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
@@ -745,6 +745,38 @@ function hideInstructionBox() {
   instruction_box.style.display = "none";
 }
 
+class ClearMapButton {
+  onAdd(map) {
+    var clear_map_button = document.createElement("button");
+    clear_map_button.href = "#";
+    clear_map_button.type = "button";
+    clear_map_button.backgroundImg = "";
+
+    clear_map_button.classList.add("active");
+    clear_map_button.classList.add("map_clear_button");
+    clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    clear_map_button.innerHTML = "<i class='fas fa-times'></i> Clear Drawing";
+    this._map = map;
+    this._container = document.createElement("div");
+    this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
+    clear_map_button.addEventListener("click", function (e) {
+      cleanAlerts();
+      draw.deleteAll();
+      hideInstructionBox();
+      updateCommunityEntry(e);
+    });
+    this._container.appendChild(clear_map_button);
+    return this._container;
+  }
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+    this._map = undefined;
+  }
+}
+map.addControl(new ClearMapButton(), "top-right");
+var map_clear_map_button = document.querySelector(".map_clear_button");
+drawControls.appendChild(map_clear_map_button);
 // add button for toggling edit mode.
 class MapEditButton {
   onAdd(map) {
@@ -783,6 +815,7 @@ map.addControl(new MapEditButton(), "top-right");
 
 var map_edit_button = document.querySelector(".map_edit_button");
 drawControls.appendChild(map_edit_button);
+
 class FinishDrawButton {
   onAdd(map) {
     var map_edit_button = document.createElement("button");
@@ -824,6 +857,8 @@ drawControls.appendChild(map_finish_drawing_button);
 
 // Add nav control buttons.
 map.addControl(new mapboxgl.NavigationControl());
+
+var user_polygon_id = undefined;
 
 // add button for toggling census Blocks
 class CensusBlocksControl {
@@ -868,6 +903,16 @@ class CensusBlocksControl {
 }
 map.addControl(new CensusBlocksControl(), "top-left");
 
+document
+  .querySelector(".map_clear_button")
+  .addEventListener("click", function (e) {
+    cleanAlerts();
+    hideInstructionBox();
+    draw.deleteAll();
+    map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
+    draw.changeMode("simple_select");
+  });
+
 // Override Behavior for Draw-Button
 document.getElementById("draw-button").addEventListener("click", function (e) {
   cleanAlerts();
@@ -880,7 +925,6 @@ document.getElementById("draw-button").addEventListener("click", function (e) {
 document.getElementById("trash-button").addEventListener("click", function (e) {
   cleanAlerts();
   hideInstructionBox();
-  draw.deleteAll();
   map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
   draw.changeMode("simple_select");
 });
@@ -1079,7 +1123,12 @@ map.on("draw.delete", function () {
 map.on("draw.update", function () {
   updateCommunityEntry();
 });
-map.on("draw.changeMode", function () {});
+map.on("draw.changeMode", function () {
+  updateCommunityEntry();
+});
+map.on("draw.selectionchange", function () {
+  updateCommunityEntry();
+});
 
 /******************************************************************************/
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -961,7 +961,17 @@ document
   .addEventListener("click", function (e) {
     cleanAlerts();
     map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
-    draw.changeMode("direct-select");
+    if (draw != null) {
+      var all_features = draw.getAll();
+      if (all_features.features.length > 0) {
+        var polygon = all_features.features[0];
+        draw.changeMode("direct_select", {
+          featureId: polygon.id,
+        });
+      } else {
+        draw.changeMode("simple_select");
+      }
+    }
   });
 
 function toggleMapButtons(state) {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -964,6 +964,7 @@ document
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         var polygon = all_features.features[0];
+        highlightBlocks(polygon);
         draw.changeMode("direct_select", {
           featureId: polygon.id,
         });
@@ -1141,7 +1142,7 @@ map.on("style.load", function () {
 });
 
 var wasLoaded = false;
-map.on("render", function () {
+map.on("render", function (event) {
   if (!map.loaded() || wasLoaded) return;
   wasLoaded = true;
   if (document.getElementById("id_user_polygon").value !== "") {
@@ -1152,26 +1153,26 @@ map.on("render", function () {
     wkt_obj = wkt.read(feature);
     var geoJsonFeature = wkt_obj.toJson();
     var featureIds = draw.add(geoJsonFeature);
-    updateCommunityEntry();
+    updateCommunityEntry(event);
   }
 });
 
 /******************************************************************************/
 
-map.on("draw.create", function () {
-  updateCommunityEntry();
+map.on("draw.create", function (event) {
+  updateCommunityEntry(event);
 });
-map.on("draw.delete", function () {
-  updateCommunityEntry();
+map.on("draw.delete", function (event) {
+  updateCommunityEntry(event);
 });
-map.on("draw.update", function () {
-  updateCommunityEntry();
+map.on("draw.update", function (event) {
+  updateCommunityEntry(event);
 });
-map.on("draw.changeMode", function () {
-  updateCommunityEntry();
+map.on("draw.changeMode", function (event) {
+  updateCommunityEntry(event);
 });
 map.on("draw.selectionchange", function (event) {
-  updateCommunityEntry();
+  updateCommunityEntry(event);
   // The event object contains the featues that were selected.
   var selected_objects = event;
   var selected_points = selected_objects.points;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -777,7 +777,7 @@ class MapEditButton {
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     map_edit_button.addEventListener("click", function (e) {
       cleanAlerts();
-      showInstructionBox();
+      toggleInstructionBox();
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         draw.changeMode("direct_select", {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -702,7 +702,7 @@ var draw = new MapboxDraw({
       filter: ["all", ["==", "$type", "Point"], ["==", "meta", "midpoint"]],
       paint: {
         "circle-radius": 5,
-        "circle-color": "#3c6382",
+        "circle-color": "#e74c3c",
       },
     },
   ],
@@ -726,6 +726,25 @@ trashButton[0].backgroundImg = "";
 trashButton[0].id = "trash-button";
 trashButton[0].innerHTML = "<i class='fas fa-trash-alt'></i> Undo Polygon";
 
+function toggleInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  if (instruction_box.style.display == "block") {
+    instruction_box.style.display = "none";
+  } else {
+    instruction_box.style.display = "block";
+  }
+}
+
+function showInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  instruction_box.style.display = "block";
+}
+
+function hideInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  instruction_box.style.display = "none";
+}
+
 // add button for toggling edit mode.
 class MapEditButton {
   onAdd(map) {
@@ -743,6 +762,7 @@ class MapEditButton {
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     map_edit_button.addEventListener("click", function (e) {
       cleanAlerts();
+      showInstructionBox();
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         draw.changeMode("direct_select", {
@@ -779,6 +799,7 @@ class FinishDrawButton {
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     map_edit_button.addEventListener("click", function (e) {
       cleanAlerts();
+      hideInstructionBox();
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         draw.changeMode("simple_select", {
@@ -850,6 +871,7 @@ map.addControl(new CensusBlocksControl(), "top-left");
 // Override Behavior for Draw-Button
 document.getElementById("draw-button").addEventListener("click", function (e) {
   cleanAlerts();
+  hideInstructionBox();
   draw.deleteAll();
   map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
   draw.changeMode("draw_polygon");
@@ -857,6 +879,7 @@ document.getElementById("draw-button").addEventListener("click", function (e) {
 
 document.getElementById("trash-button").addEventListener("click", function (e) {
   cleanAlerts();
+  hideInstructionBox();
   draw.deleteAll();
   map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
   draw.changeMode("simple_select");

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -869,7 +869,6 @@ function hideInstructionBox() {
   instruction_box.style.display = "none";
   if (draw != null) {
     var all_features = draw.getAll();
-    print(all_features);
     draw.changeMode("simple_select");
     // draw.changeMode("simple_select", {
     // featureIds: [all_features.features[0].id]

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -723,7 +723,7 @@ drawButton.id = "draw-button";
 drawButton.innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
 var delete_feature_button = document.querySelector(".mapbox-gl-draw_trash");
 delete_feature_button.backgroundImg = "";
-delete_feature_button.id = "trash-button";
+delete_feature_button.id = "delete-feature-button";
 delete_feature_button.innerHTML =
   "<i class='fas fa-minus-square'></i> Delete Vertex";
 
@@ -856,9 +856,11 @@ function showInstructionBox() {
   instruction_box.style.display = "block";
   if (draw != null) {
     var all_features = draw.getAll();
-    draw.changeMode("direct-select", {
-      featureId: all_features.features[0].id,
-    });
+    if (all_features.features.length > 0) {
+      draw.changeMode("direct_select", {
+        featureId: all_features.features[0].id,
+      });
+    }
   }
 }
 
@@ -867,9 +869,11 @@ function hideInstructionBox() {
   instruction_box.style.display = "none";
   if (draw != null) {
     var all_features = draw.getAll();
-    draw.changeMode("direct-select", {
-      featureIds: [all_features.features[0].id],
-    });
+    print(all_features);
+    draw.changeMode("simple_select");
+    // draw.changeMode("simple_select", {
+    // featureIds: [all_features.features[0].id]
+    // });
   }
 }
 
@@ -952,11 +956,13 @@ document.getElementById("draw-button").addEventListener("click", function (e) {
   draw.changeMode("draw_polygon");
 });
 
-document.getElementById("trash-button").addEventListener("click", function (e) {
-  cleanAlerts();
-  map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
-  draw.changeMode("direct-select");
-});
+document
+  .getElementById("delete-feature-button")
+  .addEventListener("click", function (e) {
+    cleanAlerts();
+    map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
+    draw.changeMode("direct-select");
+  });
 
 function toggleMapButtons(state) {
   var mapContent = document.getElementById("map");
@@ -1163,7 +1169,6 @@ map.on("draw.selectionchange", function (event) {
   var selected_features = selected_objects.features;
   if (selected_points.length > 0) {
     // The user selected a point. Show delete vertex.
-    showInstructionBox();
     showDeleteFeatureButton();
   } else {
     hideDeleteFeatureButton();

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -719,11 +719,11 @@ drawControls.classList.add("draw-group");
 /* Change mapbox draw button */
 var drawButton = document.querySelector(".mapbox-gl-draw_polygon");
 drawButton.backgroundImg = "";
-drawButton.id = "draw-button";
+drawButton.id = "draw-button-id";
 drawButton.innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
 var delete_feature_button = document.querySelector(".mapbox-gl-draw_trash");
 delete_feature_button.backgroundImg = "";
-delete_feature_button.id = "delete-feature-button";
+delete_feature_button.id = "delete-feature-button-id";
 delete_feature_button.innerHTML =
   "<i class='fas fa-minus-square'></i> Delete Vertex";
 
@@ -735,9 +735,9 @@ class ClearMapButton {
     clear_map_button.backgroundImg = "";
 
     clear_map_button.classList.add("active");
-    clear_map_button.classList.add("map_clear_button");
+    clear_map_button.classList.add("map-clear-button");
     clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
-    clear_map_button.id = "map_clear_button";
+    clear_map_button.id = "map-clear-button-id";
     clear_map_button.innerHTML =
       "<i class='fas fa-trash-alt'></i> Clear Polygon";
     this._map = map;
@@ -759,7 +759,7 @@ class ClearMapButton {
   }
 }
 map.addControl(new ClearMapButton(), "top-right");
-var map_clear_map_button = document.getElementById("map_clear_button");
+var map_clear_map_button = document.getElementById("map-clear-button-id");
 drawControls.appendChild(map_clear_map_button);
 // add button for toggling edit mode.
 class MapEditButton {
@@ -770,8 +770,9 @@ class MapEditButton {
     map_edit_button.backgroundImg = "";
 
     map_edit_button.classList.add("active");
-    map_edit_button.classList.add("map_edit_button");
+    map_edit_button.classList.add("map-edit-button");
     map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    map_edit_button.id = "map-edit-button-id";
     map_edit_button.innerHTML = "<i class='fas fa-edit'></i> Edit Polygon";
     this._map = map;
     this._container = document.createElement("div");
@@ -796,25 +797,26 @@ class MapEditButton {
   }
 }
 map.addControl(new MapEditButton(), "top-right");
-
-var map_edit_button = document.querySelector(".map_edit_button");
+var map_edit_button = document.getElementById("map-edit-button-id");
 drawControls.appendChild(map_edit_button);
 
 class FinishDrawButton {
   onAdd(map) {
-    var map_edit_button = document.createElement("button");
-    map_edit_button.href = "#";
-    map_edit_button.type = "button";
-    map_edit_button.backgroundImg = "";
+    var finish_draw_button = document.createElement("button");
+    finish_draw_button.href = "#";
+    finish_draw_button.type = "button";
+    finish_draw_button.backgroundImg = "";
 
-    map_edit_button.classList.add("active");
-    map_edit_button.classList.add("map_finish_drawing_button");
-    map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
-    map_edit_button.innerHTML = "<i class='fas fa-check'></i> Finish Drawing";
+    finish_draw_button.classList.add("active");
+    finish_draw_button.classList.add("map-finish-drawing-button");
+    finish_draw_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    finish_draw_button.id = "map-finish-drawing-button-id";
+    finish_draw_button.innerHTML =
+      "<i class='fas fa-check'></i> Finish Drawing";
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
-    map_edit_button.addEventListener("click", function (e) {
+    finish_draw_button.addEventListener("click", function (e) {
       cleanAlerts();
       hideInstructionBox();
       var all_features = draw.getAll();
@@ -824,7 +826,7 @@ class FinishDrawButton {
         });
       }
     });
-    this._container.appendChild(map_edit_button);
+    this._container.appendChild(finish_draw_button);
     return this._container;
   }
 
@@ -834,8 +836,8 @@ class FinishDrawButton {
   }
 }
 map.addControl(new FinishDrawButton(), "top-right");
-var map_finish_drawing_button = document.querySelector(
-  ".map_finish_drawing_button"
+var map_finish_drawing_button = document.getElementById(
+  "map-finish-drawing-button-id"
 );
 drawControls.appendChild(map_finish_drawing_button);
 // Add trash button last and hide it.
@@ -843,8 +845,13 @@ var oldChild = drawControls.removeChild(delete_feature_button);
 drawControls.appendChild(delete_feature_button);
 delete_feature_button.style.display = "none";
 
+function showMapEditButtons() {
+  var map_edit_button = document.getElementById("");
+}
+
 function toggleInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
+  // Show instruction box on map for edit mode.
+  var instruction_box = document.getElementById("instruction-box-id");
   if (instruction_box.style.display == "block") {
     hideInstructionBox();
   } else {
@@ -853,7 +860,7 @@ function toggleInstructionBox() {
 }
 
 function showInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
+  var instruction_box = document.getElementById("instruction-box-id");
   instruction_box.style.display = "block";
   if (draw != null) {
     var all_features = draw.getAll();
@@ -866,7 +873,7 @@ function showInstructionBox() {
 }
 
 function hideInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
+  var instruction_box = document.getElementById("instruction-box-id");
   instruction_box.style.display = "none";
   if (draw != null) {
     var all_features = draw.getAll();
@@ -938,26 +945,30 @@ class CensusBlocksControl {
 map.addControl(new CensusBlocksControl(), "top-left");
 
 document
-  .getElementById("map_clear_button")
+  .getElementById("map-clear-button-id")
   .addEventListener("click", function (e) {
     cleanAlerts();
     hideInstructionBox();
     draw.deleteAll();
     map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
     draw.changeMode("simple_select");
+    hideMapEditButtons();
   });
 
 // Override Behavior for Draw-Button
-document.getElementById("draw-button").addEventListener("click", function (e) {
-  cleanAlerts();
-  hideInstructionBox();
-  draw.deleteAll();
-  map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
-  draw.changeMode("draw_polygon");
-});
+document
+  .getElementById("draw-button-id")
+  .addEventListener("click", function (e) {
+    cleanAlerts();
+    hideInstructionBox();
+    draw.deleteAll();
+    map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
+    draw.changeMode("draw_polygon");
+    showMapEditButtons();
+  });
 
 document
-  .getElementById("delete-feature-button")
+  .getElementById("delete-feature-button-id")
   .addEventListener("click", function (e) {
     cleanAlerts();
     map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -591,7 +591,7 @@ var draw = new MapboxDraw({
         "line-join": "round",
       },
       paint: {
-        "line-color": "#60a3bc",
+        "line-color": "#2A94F4",
         "line-width": 2,
       },
     },
@@ -604,7 +604,7 @@ var draw = new MapboxDraw({
         "line-join": "round",
       },
       paint: {
-        "line-color": "#60a3bc",
+        "line-color": "#2A94F4",
         "line-dasharray": [0.2, 2],
         "line-width": 2,
       },
@@ -620,7 +620,7 @@ var draw = new MapboxDraw({
       ],
       paint: {
         "circle-radius": 10,
-        "circle-color": "#3c6382",
+        "circle-color": "#2A94F4",
       },
     },
     {
@@ -634,7 +634,7 @@ var draw = new MapboxDraw({
       ],
       paint: {
         "circle-radius": 4,
-        "circle-color": "#3c6382",
+        "circle-color": "#2A94F4",
       },
     },
     {
@@ -665,7 +665,7 @@ var draw = new MapboxDraw({
       ],
       paint: {
         "circle-radius": 3,
-        "circle-color": "#3c6382",
+        "circle-color": "#2A94F4",
       },
     },
     {
@@ -693,7 +693,7 @@ var draw = new MapboxDraw({
       ],
       paint: {
         "circle-radius": 5,
-        "circle-color": "#3c6382",
+        "circle-color": "#2A94F4",
       },
     },
     {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -737,8 +737,7 @@ class MapEditButton {
     map_edit_button.classList.add("active");
     map_edit_button.classList.add("map_edit_button");
     map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
-    map_edit_button.innerHTML =
-      "<i class='fas fa-edit'></i> <span>Edit Polygon</span>";
+    map_edit_button.innerHTML = "<i class='fas fa-edit'></i> Edit Polygon";
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
@@ -764,6 +763,43 @@ map.addControl(new MapEditButton(), "top-right");
 
 var map_edit_button = document.querySelector(".map_edit_button");
 drawControls.appendChild(map_edit_button);
+class FinishDrawButton {
+  onAdd(map) {
+    var map_edit_button = document.createElement("button");
+    map_edit_button.href = "#";
+    map_edit_button.type = "button";
+    map_edit_button.backgroundImg = "";
+
+    map_edit_button.classList.add("active");
+    map_edit_button.classList.add("map_finish_drawing_button");
+    map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    map_edit_button.innerHTML = "<i class='fas fa-check'></i> Finish Drawing";
+    this._map = map;
+    this._container = document.createElement("div");
+    this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
+    map_edit_button.addEventListener("click", function (e) {
+      cleanAlerts();
+      var all_features = draw.getAll();
+      if (all_features.features.length > 0) {
+        draw.changeMode("simple_select", {
+          featureId: all_features.features[0].id,
+        });
+      }
+    });
+    this._container.appendChild(map_edit_button);
+    return this._container;
+  }
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+    this._map = undefined;
+  }
+}
+map.addControl(new FinishDrawButton(), "top-right");
+var map_finish_drawing_button = document.querySelector(
+  ".map_finish_drawing_button"
+);
+drawControls.appendChild(map_finish_drawing_button);
 
 // Add nav control buttons.
 map.addControl(new mapboxgl.NavigationControl());

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -405,6 +405,7 @@ document.addEventListener(
       var parent_section = form_error_arr[i].closest(".card-section");
       openSectionByElement(parent_section);
     }
+    openAllSections();
     // Add a listener for the save button so sections are expanded
     // if there are errors.
     var form_save_button = document.getElementById("save");
@@ -715,9 +716,6 @@ map.addControl(draw);
 drawControls = document.querySelector(".draw_polygon_map .mapboxgl-ctrl-group");
 drawControls.classList.add("draw-group");
 
-// Add nav control buttons.
-map.addControl(new mapboxgl.NavigationControl());
-
 /* Change mapbox draw button */
 var drawButton = document.getElementsByClassName("mapbox-gl-draw_polygon");
 drawButton[0].backgroundImg = "";
@@ -727,6 +725,38 @@ var trashButton = document.getElementsByClassName("mapbox-gl-draw_trash");
 trashButton[0].backgroundImg = "";
 trashButton[0].id = "trash-button";
 trashButton[0].innerHTML = "<i class='fas fa-trash-alt'></i> Undo Polygon";
+
+// add button for toggling edit mode.
+class MapEditButton {
+  onAdd(map) {
+    var map_edit_button = document.createElement("button");
+    map_edit_button.href = "#";
+    map_edit_button.type = "button";
+    map_edit_button.backgroundImg = "";
+    map_edit_button.classList.add("active");
+    map_edit_button.classList.add("map_edit_button");
+    map_edit_button.innerHTML = "<i class='fas fa-edit'></i> Undo Polygon";
+    this._map = map;
+    this._container = document.createElement("div");
+    this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
+    map_edit_button.addEventListener("click", function (e) {
+      print("button ppressed");
+      cleanAlerts();
+      // draw.changeMode("direct_select");
+    });
+    this._container.appendChild(map_edit_button);
+    return this._container;
+  }
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+    this._map = undefined;
+  }
+}
+map.addControl(new MapEditButton(), "top-right");
+
+// Add nav control buttons.
+map.addControl(new mapboxgl.NavigationControl());
 
 // add button for toggling census Blocks
 class CensusBlocksControl {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1217,7 +1217,6 @@ map.on("draw.changeMode", function (event) {
   updateCommunityEntry(event);
 });
 map.on("draw.selectionchange", function (event) {
-  // updateCommunityEntry(event);
   // The event object contains the featues that were selected.
   var selected_objects = event;
   var selected_points = selected_objects.points;
@@ -1229,6 +1228,7 @@ map.on("draw.selectionchange", function (event) {
   } else {
     hideDeleteFeatureButton();
   }
+  updateCommunityEntry(event);
 });
 
 /******************************************************************************/
@@ -1417,6 +1417,7 @@ function updateCommunityEntry(e) {
     if (census_blocks_polygon_array != undefined) {
       census_blocks_polygon_array = census_blocks_polygon_array.join("|");
     }
+    triggerSuccessMessage();
   } else {
     // sets an empty filter - unhighlights everything
     // sets the form fields as empty
@@ -1428,10 +1429,7 @@ function updateCommunityEntry(e) {
     // "in",
     // "BLOCKID10",
     // ]);
-    triggerDrawError(
-      "no-polygon-saved",
-      "You must draw a polygon to continue."
-    );
+    triggerDrawError("polygon_missing", "You must draw a polygon to continue.");
   }
   // Update form fields
   census_blocks_polygon_wkt = "";
@@ -1442,7 +1440,6 @@ function updateCommunityEntry(e) {
   document.getElementById(
     "id_census_blocks_polygon_array"
   ).value = census_blocks_polygon_array;
-  triggerSuccessMessage();
 }
 /******************************************************************************/
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -854,14 +854,20 @@ function toggleInstructionBox() {
 function showInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
   instruction_box.style.display = "block";
-  if (delete_feature_button != null) {
-    delete_feature_button.style.display = "block";
-  }
 }
 
 function hideInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
   instruction_box.style.display = "none";
+}
+
+function showDeleteFeatureButton() {
+  if (delete_feature_button != null) {
+    delete_feature_button.style.display = "block";
+  }
+}
+
+function hideDeleteFeatureButton() {
   if (delete_feature_button != null) {
     delete_feature_button.style.display = "none";
   }
@@ -1146,8 +1152,9 @@ map.on("draw.selectionchange", function (event) {
   if (selected_points.length > 0) {
     // The user selected a point. Show delete vertex.
     showInstructionBox();
+    showDeleteFeatureButton();
   } else {
-    hideDeleteVertexButton();
+    hideDeleteFeatureButton();
   }
 });
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1367,10 +1367,10 @@ function updateCommunityEntry(e) {
     census_blocks_polygon_wkt = "";
     census_blocks_multipolygon_wkt = "";
     // TODO: update for all states
-    map.setFilter(sessionStorage.getItem("stateName") + "-blocks-highlighted", [
-      "in",
-      "BLOCKID10",
-    ]);
+    // map.setFilter(sessionStorage.getItem("stateName") + "-blocks-highlighted", [
+    // "in",
+    // "BLOCKID10",
+    // ]);
   }
   // Update form fields
   census_blocks_polygon_wkt = "";

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -737,6 +737,7 @@ class ClearMapButton {
     clear_map_button.classList.add("active");
     clear_map_button.classList.add("map_clear_button");
     clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    clear_map_button.id = "map_clear_button";
     clear_map_button.innerHTML =
       "<i class='fas fa-trash-alt'></i> Clear Polygon";
     this._map = map;
@@ -758,7 +759,7 @@ class ClearMapButton {
   }
 }
 map.addControl(new ClearMapButton(), "top-right");
-var map_clear_map_button = document.querySelector(".map_clear_button");
+var map_clear_map_button = document.getElementById("map_clear_button");
 drawControls.appendChild(map_clear_map_button);
 // add button for toggling edit mode.
 class MapEditButton {
@@ -937,7 +938,7 @@ class CensusBlocksControl {
 map.addControl(new CensusBlocksControl(), "top-left");
 
 document
-  .querySelector(".map_clear_button")
+  .getElementById("map_clear_button")
   .addEventListener("click", function (e) {
     cleanAlerts();
     hideInstructionBox();

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -738,7 +738,7 @@ class ClearMapButton {
     clear_map_button.classList.add("map_clear_button");
     clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
     clear_map_button.innerHTML =
-      "<i class='fas fa-trash-alt'></i> Clear Drawing";
+      "<i class='fas fa-trash-alt'></i> Clear Polygon";
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
@@ -854,11 +854,23 @@ function toggleInstructionBox() {
 function showInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
   instruction_box.style.display = "block";
+  if (draw != null) {
+    var all_features = draw.getAll();
+    draw.changeMode("direct-select", {
+      featureId: all_features.features[0].id,
+    });
+  }
 }
 
 function hideInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
   instruction_box.style.display = "none";
+  if (draw != null) {
+    var all_features = draw.getAll();
+    draw.changeMode("direct-select", {
+      featureIds: [all_features.features[0].id],
+    });
+  }
 }
 
 function showDeleteFeatureButton() {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -745,7 +745,6 @@ class MapEditButton {
     map_edit_button.addEventListener("click", function (e) {
       cleanAlerts();
       var all_features = draw.getAll();
-      print(all_features.features);
       if (all_features.features.length > 0) {
         draw.changeMode("direct_select", {
           featureId: all_features.features[0].id,

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -845,9 +845,9 @@ delete_feature_button.style.display = "none";
 function toggleInstructionBox() {
   var instruction_box = document.querySelector(".instruction-box");
   if (instruction_box.style.display == "block") {
-    showInstructionBox();
-  } else {
     hideInstructionBox();
+  } else {
+    showInstructionBox();
   }
 }
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -724,6 +724,7 @@ drawButton.innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
 var delete_feature_button = document.querySelector(".mapbox-gl-draw_trash");
 delete_feature_button.backgroundImg = "";
 delete_feature_button.id = "delete-feature-button-id";
+delete_feature_button.style.display = "none";
 delete_feature_button.innerHTML =
   "<i class='fas fa-minus-square'></i> Delete Vertex";
 
@@ -738,6 +739,7 @@ class ClearMapButton {
     clear_map_button.classList.add("map-clear-button");
     clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
     clear_map_button.id = "map-clear-button-id";
+    clear_map_button.style.display = "none";
     clear_map_button.innerHTML =
       "<i class='fas fa-trash-alt'></i> Clear Polygon";
     this._map = map;
@@ -772,6 +774,7 @@ class MapEditButton {
     map_edit_button.classList.add("map-edit-button");
     map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
     map_edit_button.id = "map-edit-button-id";
+    map_edit_button.style.display = "none";
     map_edit_button.innerHTML = "<i class='fas fa-edit'></i> Edit Polygon";
     this._map = map;
     this._container = document.createElement("div");
@@ -809,6 +812,7 @@ class FinishDrawButton {
     finish_draw_button.classList.add("map-finish-drawing-button");
     finish_draw_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
     finish_draw_button.id = "map-finish-drawing-button-id";
+    finish_draw_button.style.display = "none";
     finish_draw_button.innerHTML =
       "<i class='fas fa-check'></i> Finish Drawing";
     this._map = map;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -717,33 +717,15 @@ drawControls = document.querySelector(".draw_polygon_map .mapboxgl-ctrl-group");
 drawControls.classList.add("draw-group");
 
 /* Change mapbox draw button */
-var drawButton = document.getElementsByClassName("mapbox-gl-draw_polygon");
-drawButton[0].backgroundImg = "";
-drawButton[0].id = "draw-button";
-drawButton[0].innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
-var trashButton = document.getElementsByClassName("mapbox-gl-draw_trash");
-trashButton[0].backgroundImg = "";
-trashButton[0].id = "trash-button";
-trashButton[0].innerHTML = "<i class='fas fa-trash-alt'></i> Delete Selection";
-
-function toggleInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
-  if (instruction_box.style.display == "block") {
-    instruction_box.style.display = "none";
-  } else {
-    instruction_box.style.display = "block";
-  }
-}
-
-function showInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
-  instruction_box.style.display = "block";
-}
-
-function hideInstructionBox() {
-  var instruction_box = document.querySelector(".instruction-box");
-  instruction_box.style.display = "none";
-}
+var drawButton = document.querySelector(".mapbox-gl-draw_polygon");
+drawButton.backgroundImg = "";
+drawButton.id = "draw-button";
+drawButton.innerHTML = "<i class='fas fa-draw-polygon'></i> Draw Polygon";
+var delete_feature_button = document.querySelector(".mapbox-gl-draw_trash");
+delete_feature_button.backgroundImg = "";
+delete_feature_button.id = "trash-button";
+delete_feature_button.innerHTML =
+  "<i class='fas fa-minus-square'></i> Delete Vertex";
 
 class ClearMapButton {
   onAdd(map) {
@@ -755,7 +737,8 @@ class ClearMapButton {
     clear_map_button.classList.add("active");
     clear_map_button.classList.add("map_clear_button");
     clear_map_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
-    clear_map_button.innerHTML = "<i class='fas fa-times'></i> Clear Drawing";
+    clear_map_button.innerHTML =
+      "<i class='fas fa-trash-alt'></i> Clear Drawing";
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
@@ -854,6 +837,35 @@ var map_finish_drawing_button = document.querySelector(
   ".map_finish_drawing_button"
 );
 drawControls.appendChild(map_finish_drawing_button);
+// Add trash button last and hide it.
+var oldChild = drawControls.removeChild(delete_feature_button);
+drawControls.appendChild(delete_feature_button);
+delete_feature_button.style.display = "none";
+
+function toggleInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  if (instruction_box.style.display == "block") {
+    showInstructionBox();
+  } else {
+    hideInstructionBox();
+  }
+}
+
+function showInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  instruction_box.style.display = "block";
+  if (delete_feature_button != null) {
+    delete_feature_button.style.display = "block";
+  }
+}
+
+function hideInstructionBox() {
+  var instruction_box = document.querySelector(".instruction-box");
+  instruction_box.style.display = "none";
+  if (delete_feature_button != null) {
+    delete_feature_button.style.display = "none";
+  }
+}
 
 // Add nav control buttons.
 map.addControl(new mapboxgl.NavigationControl());
@@ -924,9 +936,8 @@ document.getElementById("draw-button").addEventListener("click", function (e) {
 
 document.getElementById("trash-button").addEventListener("click", function (e) {
   cleanAlerts();
-  hideInstructionBox();
   map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
-  draw.changeMode("simple_select");
+  draw.changeMode("direct-select");
 });
 
 function toggleMapButtons(state) {
@@ -1126,8 +1137,18 @@ map.on("draw.update", function () {
 map.on("draw.changeMode", function () {
   updateCommunityEntry();
 });
-map.on("draw.selectionchange", function () {
+map.on("draw.selectionchange", function (event) {
   updateCommunityEntry();
+  // The event object contains the featues that were selected.
+  var selected_objects = event;
+  var selected_points = selected_objects.points;
+  var selected_features = selected_objects.features;
+  if (selected_points.length > 0) {
+    // The user selected a point. Show delete vertex.
+    showInstructionBox();
+  } else {
+    hideDeleteVertexButton();
+  }
 });
 
 /******************************************************************************/

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -733,16 +733,24 @@ class MapEditButton {
     map_edit_button.href = "#";
     map_edit_button.type = "button";
     map_edit_button.backgroundImg = "";
+
     map_edit_button.classList.add("active");
     map_edit_button.classList.add("map_edit_button");
-    map_edit_button.innerHTML = "<i class='fas fa-edit'></i> Undo Polygon";
+    map_edit_button.classList.add("mapbox-gl-draw_ctrl-draw-btn");
+    map_edit_button.innerHTML =
+      "<i class='fas fa-edit'></i> <span>Edit Polygon</span>";
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     map_edit_button.addEventListener("click", function (e) {
-      print("button ppressed");
       cleanAlerts();
-      // draw.changeMode("direct_select");
+      var all_features = draw.getAll();
+      print(all_features.features);
+      if (all_features.features.length > 0) {
+        draw.changeMode("direct_select", {
+          featureId: all_features.features[0].id,
+        });
+      }
     });
     this._container.appendChild(map_edit_button);
     return this._container;
@@ -754,6 +762,9 @@ class MapEditButton {
   }
 }
 map.addControl(new MapEditButton(), "top-right");
+
+var map_edit_button = document.querySelector(".map_edit_button");
+drawControls.appendChild(map_edit_button);
 
 // Add nav control buttons.
 map.addControl(new mapboxgl.NavigationControl());

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1222,6 +1222,7 @@ map.on("draw.selectionchange", function (event) {
   if (selected_points.length > 0) {
     // The user selected a point. Show delete vertex.
     showDeleteFeatureButton();
+    showInstructionBox();
   } else {
     hideDeleteFeatureButton();
   }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -909,14 +909,20 @@ function hideInstructionBox() {
 }
 
 function showDeleteFeatureButton() {
-  if (delete_feature_button != null) {
-    delete_feature_button.style.display = "block";
+  var map_delete_feature_button = document.getElementById(
+    "delete-feature-button-id"
+  );
+  if (map_delete_feature_button != null) {
+    map_delete_feature_button.style.display = "block";
   }
 }
 
 function hideDeleteFeatureButton() {
-  if (delete_feature_button != null) {
-    delete_feature_button.style.display = "none";
+  var map_delete_feature_button = document.getElementById(
+    "delete-feature-button-id"
+  );
+  if (map_delete_feature_button != null) {
+    map_delete_feature_button.style.display = "none";
   }
 }
 

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -346,7 +346,12 @@
                                             <div class="map-bounding-box my-2 collapse">
                                                 <div class="map-box">
                                                     <div id='menu'></div>
-                                                    <div id='map' class='draw_polygon_map' onload="map.resize()"></div>
+                                                    <div id='map' class='draw_polygon_map' onload="map.resize()">
+                                                        <div class="instruction-box">
+                                                            <p>Click on a purple vertex to move it or delete it.</p>
+                                                            <p>Click on a red midpoint vertex to add a new vertex.</p>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                             </div>
                                             <input class="btn btn-primary float-left card-section-button button-prev" type="button" value="Previous">

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -347,7 +347,7 @@
                                                 <div class="map-box">
                                                     <div id='menu'></div>
                                                     <div id='map' class='draw_polygon_map' onload="map.resize()">
-                                                        <div class="instruction-box">
+                                                        <div id="instruction-box-id" class="instruction-box">
                                                             <p class="mb-0">Click on a blue vertex <i class="fas fa-circle blue-circle"></i> to move it or delete it. Drag vertex to move it or press "Delete Vertex" to delete it.</p>
                                                             <p class="mb-0">Click on a red midpoint vertex  <i class="fas fa-circle red-circle"></i> to add a new vertex.</p>
                                                         </div>

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -348,8 +348,8 @@
                                                     <div id='menu'></div>
                                                     <div id='map' class='draw_polygon_map' onload="map.resize()">
                                                         <div class="instruction-box">
-                                                            <p>Click on a blue vertex <i class="fas fa-circle blue-circle"></i> to move it or delete it.</p>
-                                                            <p>Click on a red midpoint vertex  <i class="fas fa-circle red-circle"></i> to add a new vertex.</p>
+                                                            <p class="mb-0">Click on a blue vertex <i class="fas fa-circle blue-circle"></i> to move it or delete it. Drag vertex to move it or press "Delete Vertex" to delete it.</p>
+                                                            <p class="mb-0">Click on a red midpoint vertex  <i class="fas fa-circle red-circle"></i> to add a new vertex.</p>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -348,8 +348,8 @@
                                                     <div id='menu'></div>
                                                     <div id='map' class='draw_polygon_map' onload="map.resize()">
                                                         <div class="instruction-box">
-                                                            <p>Click on a purple vertex to move it or delete it.</p>
-                                                            <p>Click on a red midpoint vertex to add a new vertex.</p>
+                                                            <p>Click on a blue vertex <i class="fas fa-circle blue-circle"></i> to move it or delete it.</p>
+                                                            <p>Click on a red midpoint vertex  <i class="fas fa-circle red-circle"></i> to add a new vertex.</p>
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
Closes  #86. Closes #61.

- Adds "Edit Polygon" button that puts the map in "direct_select" mode where the users can select vertices to remove them or add new ones.
- Adds "Finish Drawing" button that makes it easier for new users to finish drawing a polygon (they don't have to figure out that you need to connect the final vertices or press the "Enter" key).
- Adds "Clear Polygon" button that removes anything that's on the map.
- Adds "Delete Vertex" button that removes one vertex at a time (repurposed Mapbox delete button).
- Adds information box that helps users understand how to edit the drawn polygon.
- Adds the Representable.org colors to the Readme for easy reference.
- Temporary (before we update the form altogether): Expands all sections by default.

**What to look for:**
- Go to entry page. 
- Go to map drawing section.
- Draw Polygon.
- Clear Polygon. See that everything is cleared.
- Draw another polygon. Press on 'Edit Polygon' button.
- Select one vertex and delete it.
- Finish Drawing. Check that map is ok.
- Clear Polygon. Draw another one.
- Delete vertex one by one to see that it clear everything.

<img width="944" alt="Screen Shot 2020-05-24 at 00 03 23" src="https://user-images.githubusercontent.com/8714338/82745503-34172580-9d53-11ea-9d04-6155812b4b25.png">
<img width="1034" alt="Screen Shot 2020-05-24 at 00 03 34" src="https://user-images.githubusercontent.com/8714338/82745504-35e0e900-9d53-11ea-90f4-2654b082ac16.png">
<img width="1024" alt="Screen Shot 2020-05-24 at 00 03 39" src="https://user-images.githubusercontent.com/8714338/82745506-37121600-9d53-11ea-8fee-3d09bc7950ff.png">
<img width="970" alt="Screen Shot 2020-05-24 at 00 03 52" src="https://user-images.githubusercontent.com/8714338/82745512-4002e780-9d53-11ea-9a5b-2bb33b26a477.png">
