### PR TITLE
Form Validation Updates

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -15,7 +15,15 @@ and rules, since this can lead to unintended consequences.
 This means no changing anything like <a>, <li>, <p>, etc.
 */
 
-input:invalid {
+form:invalid {
+  border-color: red;
+}
+
+.has_error {
+  border-color: red;
+}
+
+.has_success {
   border-color: red;
 }
 

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -15,6 +15,10 @@ and rules, since this can lead to unintended consequences.
 This means no changing anything like <a>, <li>, <p>, etc.
 */
 
+input:invalid {
+  border: 1px solid red;
+}
+
 /* TOC Checkbox*/
 .toc-check {
   display: inline;
@@ -192,13 +196,13 @@ footer {
 /* Help dropup */
 
 #dropuphelp {
-  position: fixed; 
-  bottom: 40px; 
-  right: 40px; 
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
   z-index: 1010;
 }
 
-.dropdown-menu a{
+.dropdown-menu a {
   color: #333;
 }
 
@@ -208,8 +212,8 @@ footer {
 /* Bootstrap Buttons. */
 
 #video_popup {
-  position: fixed; 
-  bottom: 90px; 
+  position: fixed;
+  bottom: 90px;
   right: 24px;
   z-index: 1000;
 }
@@ -350,18 +354,19 @@ color scheme. See readme.md*/
 }
 
 /* override what the popup looks like on small devices */
-@media (max-width:600px)  { 
-  #video_popup {  
-    width:300px;
+@media (max-width: 600px) {
+  #video_popup {
+    width: 300px;
     bottom: 90px;
-    right: 10px; 
-    z-index: 1000 !important;}
+    right: 10px;
+    z-index: 1000 !important;
+  }
 
   #video_popup_body {
     padding-right: 0.05rem;
     padding-left: 0.05rem;
-   }
   }
+}
 
 /* Style the sidenav links and the dropdown button */
 
@@ -376,7 +381,7 @@ color scheme. See readme.md*/
   outline: none;
 }
 
-.comm-content .more-content{
+.comm-content .more-content {
   display: none;
 }
 

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -16,7 +16,7 @@ This means no changing anything like <a>, <li>, <p>, etc.
 */
 
 input:invalid {
-  border: 1px solid red;
+  border-color: red;
 }
 
 /* TOC Checkbox*/

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -293,6 +293,29 @@ function parseReverseGeo(geoData) {
 }
 
 /******************************************************************************/
+
+function formValidation() {
+  // Check Poly Fields And Display Errors On Save
+  print("form validation");
+  var user_polygon_field = document.getElementById("id_user_polygon");
+  if (user_polygon_field.value == null || user_polygon_field.value == "") {
+    triggerMissingPolygonError();
+    return false;
+  }
+  var census_blocks_arr_field = document.getElementById(
+    "id_census_blocks_polygon_array"
+  );
+  if (
+    census_blocks_arr_field.value == null ||
+    census_blocks_arr_field.value == ""
+  ) {
+    triggerMissingPolygonError();
+    return false;
+  }
+  var census_blocks_poly = document.getElementById("id_census_blocks_polygon");
+  return true;
+}
+
 // Make buttons show the right skin.
 document.addEventListener(
   "DOMContentLoaded",
@@ -305,14 +328,10 @@ document.addEventListener(
       .removeClass("add-form-row")
       .addClass("remove-form-row")
       .html('<span class="" aria-hidden="true">Remove</span>');
-    // Check Poly Fields And Display Errors On Save
-    var user_polygon_field = document.getElementById("id_user_polygon");
-    var census_blocks_arr_field = document.getElementById(
-      "id_census_blocks_polygon_array"
-    );
-    var census_blocks_poly = document.getElementById(
-      "id_census_blocks_polygon"
-    );
+    var entry_form_button = document.getElementById("save");
+    entry_form_button.addEventListener("click", function (event) {
+      formValidation();
+    });
   },
   false
 );
@@ -1083,7 +1102,15 @@ function cleanAlerts() {
   }
 }
 
+function triggerMissingPolygonError() {
+  triggerDrawError(
+    "polygon_missing",
+    "You must draw a polygon to submit this entry."
+  );
+}
+
 function triggerDrawError(id, stringErrorText) {
+  print("appended error");
   /*
         triggerDrawError creates a bootstrap alert placed on top of the map.
     */
@@ -1110,6 +1137,7 @@ function triggerDrawError(id, stringErrorText) {
                                   </button>\
                           </div>';
   document.getElementById("map-error-alerts").appendChild(newAlert);
+  print("appended error");
 }
 
 /******************************************************************************/
@@ -1251,7 +1279,7 @@ function updateCommunityEntry(event) {
       "in",
       "BLOCKID10",
     ]);
-    triggerDrawError("polygon_missing", "You must draw a polygon to continue.");
+    triggerMissingPolygonError();
   } else {
     // Update User Polygon with the GeoJson data.
     drawn_polygon = data.features[0];

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -308,7 +308,6 @@ function checkFieldById(field_id) {
   var field = document.getElementById(field_id);
   if (field.value == null || field.value == "") {
     field.classList.add("has_error");
-    print(field.id);
     return false;
   }
   field.classList.add("hass_success");
@@ -326,7 +325,6 @@ function formValidation() {
       }
     }
   }
-  print("hello");
 
   var cultural_interests_field = document.getElementById(
     "id_cultural_interests"
@@ -345,7 +343,6 @@ function formValidation() {
     comm_activities_field.value == "" &&
     other_considerations_field.value == ""
   ) {
-    print("test");
     cultural_interests_field.classList.add("has_error");
     economic_intetersts_field.classList.add("has_error");
     comm_activities_field.classList.add("has_error");
@@ -391,6 +388,12 @@ document.addEventListener(
       formValidation();
     });
     state = sessionStorage.getItem("state_code");
+    // If there are alerts, scroll to first one.
+    var document_alerts = document.getElementsByClassName("django-alert");
+    if (document_alerts.length > 0) {
+      let first_alert = document_alerts[0];
+      first_alert.scrollIntoView();
+    }
   },
   false
 );

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -307,32 +307,58 @@ function hideMap() {
 function checkFieldById(field_id) {
   var field = document.getElementById(field_id);
   if (field.value == null || field.value == "") {
-    field.classList.add("has-error");
+    field.classList.add("has_error");
+    print(field.id);
     return false;
   }
-  field.classList.add("has-success");
+  field.classList.add("hass_success");
   return true;
 }
 
 function formValidation() {
   // Check Normal Fields
+  var flag = true;
   var form_elements = document.getElementById("entryForm").elements;
   for (var i = 0; i < form_elements.length; i++) {
     if (form_elements[i].required) {
       if (!checkFieldById(form_elements[i].id)) {
-        return false;
+        flag = false;
       }
     }
   }
+  print("hello");
 
-  var user_name = document.getElementById("id_user_name");
-  if (user_name.value == null || user_name.value == "") {
+  var cultural_interests_field = document.getElementById(
+    "id_cultural_interests"
+  );
+  var economic_intetersts_field = document.getElementById(
+    "id_economic_interests"
+  );
+  var comm_activities_field = document.getElementById("id_comm_activities");
+  var other_considerations_field = document.getElementById(
+    "id_other_considerations"
+  );
+
+  if (
+    cultural_interests_field.value == "" &&
+    economic_intetersts_field.value == "" &&
+    comm_activities_field.value == "" &&
+    other_considerations_field.value == ""
+  ) {
+    print("test");
+    cultural_interests_field.classList.add("has_error");
+    economic_intetersts_field.classList.add("has_error");
+    comm_activities_field.classList.add("has_error");
+    other_considerations_field.classList.add("has_error");
+    var interets_alert = document.getElementById("need_one_interest");
+    interets_alert.classList.remove("d-none").add("d-block");
   }
+
   // Check Poly Fields And Display Errors On Save
   var user_polygon_field = document.getElementById("id_user_polygon");
   if (user_polygon_field.value == null || user_polygon_field.value == "") {
     triggerMissingPolygonError();
-    return false;
+    flag = false;
   }
   var census_blocks_arr_field = document.getElementById(
     "id_census_blocks_polygon_array"
@@ -342,10 +368,10 @@ function formValidation() {
     census_blocks_arr_field.value == ""
   ) {
     triggerMissingPolygonError();
-    return false;
+    flag = false;
   }
   var census_blocks_poly = document.getElementById("id_census_blocks_polygon");
-  return true;
+  return flag;
 }
 
 // Make buttons show the right skin.

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -320,7 +320,6 @@ function formValidation() {
   for (var i = 0; i < form_elements.length; i++) {
     if (form_elements[i].required) {
       if (!checkFieldById(form_elements[i].id)) {
-        print(form_elements[i].id);
         return false;
       }
     }
@@ -888,7 +887,6 @@ document
 document
   .getElementById("draw-button-id")
   .addEventListener("click", function (event) {
-    print("draw listener");
     hideInstructionBox();
     draw.deleteAll();
     map.setFilter(state + "-blocks-highlighted", ["in", "BLOCKID10"]);
@@ -1032,7 +1030,6 @@ map.on("style.load", function () {
 
   for (let i = 0; i < states.length; i++) {
     // newCensusLines(states[i]);
-    print("LOADED HIGHLIGHT LAYER");
     newCensusShading(states[i]);
     newHighlightLayer(states[i]);
   }
@@ -1088,7 +1085,6 @@ map.on("render", function (event) {
     wkt_obj = wkt.read(feature);
     var geoJsonFeature = wkt_obj.toJson();
     var featureIds = draw.add(geoJsonFeature);
-    print(geoJsonFeature.coordinates[0]);
     updateCommunityEntry(event);
     map.flyTo({
       center: geoJsonFeature.coordinates[0][0],
@@ -1102,22 +1098,17 @@ map.on("render", function (event) {
 
 map.on("draw.create", function (event) {
   updateCommunityEntry(event);
-  print("create");
 });
 map.on("draw.delete", function (event) {
   updateCommunityEntry(event);
-  print("delete");
 });
 map.on("draw.update", function (event) {
   updateCommunityEntry(event);
-  print("updated");
 });
 map.on("draw.changeMode", function (event) {
-  print("change mode");
   updateCommunityEntry(event);
 });
 map.on("draw.selectionchange", function (event) {
-  print("selection_change");
   // The event object contains the featues that were selected.
   var selected_objects = event;
   var selected_points = selected_objects.points;
@@ -1151,7 +1142,6 @@ function triggerMissingPolygonError() {
 }
 
 function triggerDrawError(id, stringErrorText) {
-  print("appended error");
   /*
         triggerDrawError creates a bootstrap alert placed on top of the map.
     */
@@ -1178,7 +1168,6 @@ function triggerDrawError(id, stringErrorText) {
                                   </button>\
                           </div>';
   document.getElementById("map-error-alerts").appendChild(newAlert);
-  print("appended error");
 }
 
 /******************************************************************************/
@@ -1335,11 +1324,9 @@ function updateCommunityEntry(event) {
       draw.trash();
       return;
     }
-    print("after kinks");
     // Calculate area and convert it from square meters into square miles.
     let area = turf.area(data);
     area = turf.convertArea(area, "meters", "miles");
-    print("after area");
     // coi is not too big
     let halfStateArea = state_areas[state] / 2;
     if (area > halfStateArea) {
@@ -1348,17 +1335,14 @@ function updateCommunityEntry(event) {
         "Polygon area too large. Please draw your community again."
       );
       draw.trash();
-      print("in trash!");
       return;
     }
-    print("after trash");
     // Save user polygon.
     var user_polygon_json = JSON.stringify(drawn_polygon["geometry"]);
     wkt_obj = wkt.read(user_polygon_json);
     user_polygon_wkt = wkt_obj.write();
     // save census blocks multipolygon
     census_blocks_polygon_array = highlightBlocks(drawn_polygon);
-    print("after highlight");
     if (census_blocks_polygon_array != undefined) {
       census_blocks_polygon_array = census_blocks_polygon_array.join("|");
     }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -852,7 +852,6 @@ document
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         var polygon = all_features.features[0];
-        highlightBlocks(polygon);
         updateCommunityEntry(event);
         draw.changeMode("direct_select", {
           featureId: polygon.id,
@@ -1213,19 +1212,13 @@ function addPoly(poly, polyArray, wkt) {
   return polyArray;
 }
 
-function updateFormFields(
-  user_polygon_wkt,
-  census_blocks_polygon_wkt,
-  census_blocks_polygon_array
-) {
+function updateFormFields(user_polygon_wkt, census_blocks_polygon_array) {
   // Update form fields
   document.getElementById("id_user_polygon").value = user_polygon_wkt;
   document.getElementById(
-    "id_census_blocks_polygon"
-  ).value = census_blocks_polygon_wkt;
-  document.getElementById(
     "id_census_blocks_polygon_array"
   ).value = census_blocks_polygon_array;
+  // "census_blocks_polygon" gets saved in the post() function in django
 }
 
 /* Responds to the user's actions and updates the geometry fields and the arrayfield
@@ -1237,9 +1230,8 @@ function updateCommunityEntry(event) {
   var data = draw.getAll();
   var data_features = data.features;
   var user_polygon_wkt = "";
-  var census_blocks_polygon_wkt = "";
   var drawn_polygon = "";
-  var census_blocks_polygon_array = "";
+  var census_blocks_polygon_array;
 
   // Check if the feature has data
   if (data_features.length > 0) {
@@ -1255,10 +1247,10 @@ function updateCommunityEntry(event) {
     // sets an empty filter - unhighlights everything
     // sets the form fields as empty
     // TODO: update for all states
-    // map.setFilter(sessionStorage.getItem("stateName") + "-blocks-highlighted", [
-    // "in",
-    // "BLOCKID10",
-    // ]);
+    map.setFilter(sessionStorage.getItem("stateName") + "-blocks-highlighted", [
+      "in",
+      "BLOCKID10",
+    ]);
     triggerDrawError("polygon_missing", "You must draw a polygon to continue.");
   } else {
     // Update User Polygon with the GeoJson data.
@@ -1303,11 +1295,7 @@ function updateCommunityEntry(event) {
     }
     triggerSuccessMessage();
   }
-  updateFormFields(
-    user_polygon_wkt,
-    census_blocks_polygon_wkt,
-    census_blocks_polygon_array
-  );
+  updateFormFields(user_polygon_wkt, census_blocks_polygon_array);
 }
 /******************************************************************************/
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -665,9 +665,8 @@ class FinishDrawButton {
         draw.changeMode("simple_select", {
           featureId: all_features.features[0].id,
         });
-        print("features!!!");
+        updateCommunityEntry(event);
       }
-      updateCommunityEntry(event);
     });
     this._container.appendChild(finish_draw_button);
     return this._container;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1213,6 +1213,21 @@ function addPoly(poly, polyArray, wkt) {
   return polyArray;
 }
 
+function updateFormFields(
+  user_polygon_wkt,
+  census_blocks_polygon_wkt,
+  census_blocks_polygon_array
+) {
+  // Update form fields
+  document.getElementById("id_user_polygon").value = user_polygon_wkt;
+  document.getElementById(
+    "id_census_blocks_polygon"
+  ).value = census_blocks_polygon_wkt;
+  document.getElementById(
+    "id_census_blocks_polygon_array"
+  ).value = census_blocks_polygon_array;
+}
+
 /* Responds to the user's actions and updates the geometry fields and the arrayfield
  in the form. */
 function updateCommunityEntry(event) {
@@ -1288,15 +1303,11 @@ function updateCommunityEntry(event) {
     }
     triggerSuccessMessage();
   }
-
-  // Update form fields
-  document.getElementById("id_user_polygon").value = user_polygon_wkt;
-  document.getElementById(
-    "id_census_blocks_polygon"
-  ).value = census_blocks_polygon_wkt;
-  document.getElementById(
-    "id_census_blocks_polygon_array"
-  ).value = census_blocks_polygon_array;
+  updateFormFields(
+    user_polygon_wkt,
+    census_blocks_polygon_wkt,
+    census_blocks_polygon_array
+  );
 }
 /******************************************************************************/
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -348,7 +348,7 @@ function formValidation() {
     comm_activities_field.classList.add("has_error");
     other_considerations_field.classList.add("has_error");
     var interets_alert = document.getElementById("need_one_interest");
-    interets_alert.classList.remove("d-none").add("d-block");
+    interets_alert.classList.remove("d-none");
   }
 
   // Check Poly Fields And Display Errors On Save
@@ -368,6 +368,10 @@ function formValidation() {
     flag = false;
   }
   var census_blocks_poly = document.getElementById("id_census_blocks_polygon");
+  if (flag == false) {
+    // Add alert.
+    document.getElementById("form_error").classList.remove("d-none");
+  }
   return flag;
 }
 
@@ -393,6 +397,7 @@ document.addEventListener(
     if (document_alerts.length > 0) {
       let first_alert = document_alerts[0];
       first_alert.scrollIntoView();
+      document.getElementById("form_error").classList.remove("d-none");
     }
   },
   false

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -387,7 +387,7 @@ document.addEventListener(
     entry_form_button.addEventListener("click", function (event) {
       formValidation();
     });
-    state = sessionStorage.getItem("state_code");
+    state = sessionStorage.getItem("state_name");
     // If there are alerts, scroll to first one.
     var document_alerts = document.getElementsByClassName("django-alert");
     if (document_alerts.length > 0) {
@@ -1098,7 +1098,7 @@ map.on("style.load", function () {
       neighbors = new_neighbors;
     }
     // Save state to session storage
-    sessionStorage.setItem("state_code", state);
+    sessionStorage.setItem("state_name", state);
   });
 });
 
@@ -1321,12 +1321,17 @@ function updateCommunityEntry(event) {
   var census_blocks_polygon_array;
 
   // Check if the feature has data
-  if (data_features.length > 0) {
+  if (data_features && data_features.length > 0) {
     var data_geometry = data.features[0].geometry;
     // .coordinates stores an array in an array. The nested array contains
     // the points.
     var coordinates = data_geometry.coordinates[0];
-    var coordinates_length = coordinates.length;
+    var coordinates_length;
+    if (coordinates) {
+      coordinates_length = coordinates.length;
+    } else {
+      coordinates_length = 0;
+    }
   }
 
   // Check if the map stores a valid polygon
@@ -1334,10 +1339,10 @@ function updateCommunityEntry(event) {
     // sets an empty filter - unhighlights everything
     // sets the form fields as empty
     // TODO: update for all states
-    map.setFilter(sessionStorage.getItem("stateName") + "-blocks-highlighted", [
-      "in",
-      "BLOCKID10",
-    ]);
+    map.setFilter(
+      sessionStorage.getItem("state_name") + "-blocks-highlighted",
+      ["in", "BLOCKID10"]
+    );
     triggerMissingPolygonError();
   } else {
     // Update User Polygon with the GeoJson data.

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -659,11 +659,13 @@ class FinishDrawButton {
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     finish_draw_button.addEventListener("click", function (event) {
       hideInstructionBox();
+      print("Draw button listener");
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         draw.changeMode("simple_select", {
           featureId: all_features.features[0].id,
         });
+        print("features!!!");
       }
       updateCommunityEntry(event);
     });
@@ -1216,6 +1218,7 @@ function updateCommunityEntry(e) {
   var user_polygon_wkt;
   var census_blocks_polygon_wkt;
   var drawn_polygon;
+  var census_blocks_polygon_array;
   if (data.features.length > 0) {
     // Update User Polygon with the GeoJson data.
     drawn_polygon = data.features[0];
@@ -1255,6 +1258,7 @@ function updateCommunityEntry(e) {
     }
     triggerSuccessMessage();
   } else {
+    print("TEST");
     // sets an empty filter - unhighlights everything
     // sets the form fields as empty
     user_polygon_wkt = "";

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -365,6 +365,7 @@ document.addEventListener(
     entry_form_button.addEventListener("click", function (event) {
       formValidation();
     });
+    state = sessionStorage.getItem("state_code");
   },
   false
 );
@@ -1031,6 +1032,7 @@ map.on("style.load", function () {
 
   for (let i = 0; i < states.length; i++) {
     // newCensusLines(states[i]);
+    print("LOADED HIGHLIGHT LAYER");
     newCensusShading(states[i]);
     newHighlightLayer(states[i]);
   }
@@ -1069,6 +1071,8 @@ map.on("style.load", function () {
       state = new_state;
       neighbors = new_neighbors;
     }
+    // Save state to session storage
+    sessionStorage.setItem("state_code", state);
   });
 });
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1088,7 +1088,13 @@ map.on("render", function (event) {
     wkt_obj = wkt.read(feature);
     var geoJsonFeature = wkt_obj.toJson();
     var featureIds = draw.add(geoJsonFeature);
+    print(geoJsonFeature.coordinates[0]);
     updateCommunityEntry(event);
+    map.flyTo({
+      center: geoJsonFeature.coordinates[0][0],
+      essential: true, // this animation is considered essential with respect to prefers-reduced-motion
+      zoom: 8,
+    });
   }
 });
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -659,7 +659,6 @@ class FinishDrawButton {
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
     finish_draw_button.addEventListener("click", function (event) {
       hideInstructionBox();
-      print("Draw button listener");
       var all_features = draw.getAll();
       if (all_features.features.length > 0) {
         draw.changeMode("simple_select", {
@@ -1257,7 +1256,6 @@ function updateCommunityEntry(e) {
     }
     triggerSuccessMessage();
   } else {
-    print("TEST");
     // sets an empty filter - unhighlights everything
     // sets the form fields as empty
     user_polygon_wkt = "";

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -294,6 +294,16 @@ function parseReverseGeo(geoData) {
 
 /******************************************************************************/
 
+function showMap() {
+  $(".map-bounding-box.collapse").collapse("show");
+  map.resize();
+}
+
+function hideMap() {
+  $(".map-bounding-box.collapse").collapse("hide");
+  map.resize();
+}
+
 function formValidation() {
   // Check Poly Fields And Display Errors On Save
   print("form validation");
@@ -1021,9 +1031,7 @@ map.on("style.load", function () {
     var styleSpecBox = document.getElementById("json-response");
     var styleSpecText = JSON.stringify(styleSpec, null, 2);
 
-    $(".map-bounding-box.collapse").collapse("show");
-    map.resize();
-
+    showMap();
     // get the state from the geocoder response
     if (styleSpec.context.length >= 2) {
       new_state = styleSpec.context[styleSpec.context.length - 2]["short_code"]
@@ -1322,6 +1330,7 @@ function updateCommunityEntry(event) {
       census_blocks_polygon_array = census_blocks_polygon_array.join("|");
     }
     triggerSuccessMessage();
+    showMap();
   }
   updateFormFields(user_polygon_wkt, census_blocks_polygon_array);
 }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -304,9 +304,32 @@ function hideMap() {
   map.resize();
 }
 
+function checkFieldById(field_id) {
+  var field = document.getElementById(field_id);
+  if (field.value == null || field.value == "") {
+    field.classList.add("has-error");
+    return false;
+  }
+  field.classList.add("has-success");
+  return true;
+}
+
 function formValidation() {
+  // Check Normal Fields
+  var form_elements = document.getElementById("entryForm").elements;
+  for (var i = 0; i < form_elements.length; i++) {
+    if (form_elements[i].required) {
+      if (!checkFieldById(form_elements[i].id)) {
+        print(form_elements[i].id);
+        return false;
+      }
+    }
+  }
+
+  var user_name = document.getElementById("id_user_name");
+  if (user_name.value == null || user_name.value == "") {
+  }
   // Check Poly Fields And Display Errors On Save
-  print("form validation");
   var user_polygon_field = document.getElementById("id_user_polygon");
   if (user_polygon_field.value == null || user_polygon_field.value == "") {
     triggerMissingPolygonError();

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -561,6 +561,7 @@
                                                 <!-- Google translate  -->
                                                 Busque una ubicación para comenzar a dibujar su comunidad.
                                                 {% endif %}
+                                                <small class="text-danger">(Required)</small>
                                             </strong>
                                             <button class="btn btn-secondary btn-sm mb-2 float-right" onclick="showVideoPopup()" type="button">Video Tutorial</button>
                                             <div id="geocoder" class="geocoder my-3"></div>

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -41,7 +41,7 @@
             <!-- START FORM BODY -->
             <div class="row mt-3">
                 <!-- Entry Form -->
-                <form id="entryForm" method="post">
+                <form id="entryForm" method="post" onSubmit="return validate();">
                     <div class="row row-equal-cols">
                         <div class="col-lg  m-2">
                             <h2 class="text-primary">

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -68,6 +68,15 @@
                                 This form will help you add your community to Representable so you can
                                 make sure your voice is heard.
                             </p>
+                            {% csrf_token %}
+                            <!-- {# Include the non-field error fields #} -->
+                            {% if comm_form.non_field_errors %}
+                            <div class="non-field-errors form-error">
+                                {% for err in comm_form.non_field_errors %}
+                                <p class="form-error">{{ err }}</p>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
                         </div>
                     </div>
                     <div class="row row-equal-cols">
@@ -289,15 +298,7 @@
                                             </div>
                                         </div>
                                         {% endif %}
-                                        {% csrf_token %}
-                                        <!-- {# Include the non-field error fields #} -->
-                                        {% if comm_form.non_field_errors %}
-                                        <div class="non-field-errors form-error">
-                                            {% for err in comm_form.non_field_errors %}
-                                            <p class="form-error">{{ err }}</p>
-                                            {% endfor %}
-                                        </div>
-                                        {% endif %}
+
                                         <div id="main_community_form" class="form-group">
                                             <!-- {# Include the hidden fields #} -->
                                             {% for hidden in comm_form.hidden_fields %}

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -77,6 +77,17 @@
                                 {% endfor %}
                             </div>
                             {% endif %}
+                            {% if comm_form.errors %}
+                            <div id="django_form_errors">
+                            </div>
+                            {% endif %}
+                            <div id="form_error" class="alert alert-danger alert-dismissible fade show form-error d-none" role="alert">
+                                There was an error in submitting your community. Please check over and 
+                                ensure that you have filled out all required fields.
+                                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
                         </div>
                     </div>
                     <div class="row row-equal-cols">

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -291,6 +291,12 @@
                                             </div>
                                         </div>
                                         {% endif %}
+                                        <div id="need_one_interest" class="alert alert-danger alert-dismissible fade show form-error d-none" role="alert">
+                                            Please fill out at least one of the interest fields.
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
                                         <!-- Cultural -->
                                         <h5 class="card-text">Cultural Interests</h5>
                                         <!-- <div id="cultural_interests_error_alerts">

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -101,6 +101,23 @@
                                                 </p>
                                             </div>
                                         </div>
+                                        <div id="user_name_error_alerts">
+                                            {% if comm_form.user_name.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="user_name_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.user_name.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <p class="card-text">
                                             Your Name <small class="text-danger">(Required)</small>
                                         </p>
@@ -137,18 +154,103 @@
                                                 {{ comm_form.user_phone|append_attr:"class:form-control" }}
                                             </div>
                                         </div>
+                                        <div id="addr_form_error_alerts">
+                                            {% if addr_form.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="addr_form_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in addr_form.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <p class="card-text">
                                             Your Address <small class="text-danger">(Required)</small>
                                         </p>
+                                        <div id="street_error_alerts">
+                                            {% if addr_form.street.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="street_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in addr_form.street.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <div class="form-row my-2">
                                             <div class="col-6">
                                                 {{ addr_form.street|append_attr:"class:form-control" }}
                                             </div>
                                         </div>
+                                        <div id="city_error_alerts">
+                                            {% if addr_form.city.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="city_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in addr_form.city.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <div class="form-row my-2">
                                             <div class="col-4">
                                                 {{ addr_form.city|append_attr:"class:form-control" }}
                                             </div>
+                                        </div>
+                                        <div id="state_error_alerts">
+                                            {% if addr_form.state.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="state_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in addr_form.state.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
+                                        <div id="zipcode_error_alerts">
+                                            {% if addr_form.zipcode.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="zipcode_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in addr_form.zipcode.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
                                         </div>
                                         <div class="form-row my-2">
                                             <div class="col-2">
@@ -187,11 +289,27 @@
                                                     <span aria-hidden="true">&times;</span>
                                                 </button>
                                             </div>
-                                            
                                         </div>
                                         {% endif %}
                                         <!-- Cultural -->
                                         <h5 class="card-text">Cultural Interests</h5>
+                                        <!-- <div id="cultural_interests_error_alerts">
+                                            {% if comm_form.cultural_interests.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="cultural_interests_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.cultural_interests.errors %}
+                                                        <li class="m-0">{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div> -->
                                         <p class="card-text mb-0">
                                             What fosters a sense of belonging in your community? 
                                             What common beliefs or values exist? <small class="text-primary">(Recommended)</small>
@@ -212,6 +330,23 @@
                                         <hr>
                                         <!-- Activities -->
                                         <h5 class="card-text">Community Activities and Services</h5>
+                                        <!-- <div id="activities_error_alerts">
+                                            {% if comm_form.comm_activities.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="activities_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul>
+                                                    {% for error in comm_form.comm_activities.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div> -->
                                         <p class="card-text mb-0">
                                             Where do people in your community gather or socialize? 
                                             Where does your community get its services? <small class="text-primary">(Recommended)</small>
@@ -232,6 +367,23 @@
                                         <hr>
                                         <!--  Economic -->
                                         <h5 class="card-text">Economic Interests</h5>
+                                        <!-- <div id="economic_error_alerts">
+                                            {% if comm_form.economic_interests.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="economic_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.economic_interests.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div> -->
                                         <p class="card-text mb-0">
                                             Is there a shared economy in the geographic area of your community? 
                                             How and where are residents employed? What parts of a county, 
@@ -254,6 +406,23 @@
                                         <hr>
                                         <!-- Other -->
                                         <h5 class="card-text">Other Interests</h5>
+                                        <!-- <div id="other_error_alerts">
+                                            {% if comm_form.other_considerations.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="economic_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.other_consideration.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div> -->
                                         <p class="card-text mb-1">
                                             What other interests does your community care about? Please add anything
                                             that does not fit in the sections above. <small class="text-primary">(Recommended)</small>
@@ -272,6 +441,23 @@
                                         <strong>3. Your Community's Issues and Name</strong>
                                     </div>
                                     <div class="card-body">
+                                        <div id="entry_reason_error_alerts">
+                                            {% if comm_form.entry_reason.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="entry_reason_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.entry_reason.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <p class="card-text">
                                             What are the issues facing your community and do you have any suggestions
                                             for how the redistricting commission in your state could help address these issues?<small class="text-primary"> (Recommended)</small>
@@ -279,6 +465,23 @@
                                         </p>
                                         {{ comm_form.entry_reason|append_attr:"class:form-control" }}
                                         <hr>
+                                        <div id="entry_name_error_alerts">
+                                            {% if comm_form.entry_name.errors %}
+                                                <script>
+                                                    sessionStorage.setItem("allChecks", "fail");
+                                                </script>
+                                                <div id="entry_name_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                    <ul class="m-0">
+                                                    {% for error in comm_form.entry_name.errors %}
+                                                        <li>{{ error|escape }}</li>
+                                                    {% endfor %}
+                                                    </ul>
+                                                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                                                        <span aria-hidden="true">&times;</span>
+                                                    </button>
+                                                </div>
+                                            {% endif %}
+                                        </div>
                                         <p class="card-text">
                                             What name can we use to identify your community? <small class="text-danger">(Required)</small>
                                             <!-- TODO we should find a better example -->

--- a/main/templates/main/pages/entry.html
+++ b/main/templates/main/pages/entry.html
@@ -106,7 +106,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="user_name_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="user_name_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.user_name.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -132,7 +132,7 @@
                                             <script>
                                                 sessionStorage.setItem("allChecks", "fail");
                                             </script>
-                                            <div id="phone_invalid" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                            <div id="phone_invalid" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                 {% if LANGUAGE_CODE == 'en' %}
                                                 Please enter a valid US Phone Number.
                                                 {% elif LANGUAGE_CODE == 'es' %}
@@ -159,7 +159,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="addr_form_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="addr_form_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in addr_form.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -179,7 +179,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="street_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="street_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in addr_form.street.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -201,7 +201,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="city_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="city_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in addr_form.city.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -223,7 +223,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="state_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="state_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in addr_form.state.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -240,7 +240,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="zipcode_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="zipcode_errors" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in addr_form.zipcode.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -278,7 +278,7 @@
                                             <script>
                                                 sessionStorage.setItem("allChecks", "fail");
                                             </script>
-                                            <div id="interests_missing" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                            <div id="interests_missing" class="alert  django-alert alert-dismissible fade show form-error" role="alert">
                                                 {% if LANGUAGE_CODE == 'en' %}
                                                 Please fill out at least one of the interest fields.
                                                 {% elif LANGUAGE_CODE == 'es' %}
@@ -304,7 +304,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="cultural_interests_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="cultural_interests_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.cultural_interests.errors %}
                                                         <li class="m-0">{{ error|escape }}</li>
@@ -341,7 +341,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="activities_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="activities_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul>
                                                     {% for error in comm_form.comm_activities.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -378,7 +378,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="economic_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="economic_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.economic_interests.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -417,7 +417,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="economic_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="economic_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.other_consideration.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -452,7 +452,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="entry_reason_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="entry_reason_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.entry_reason.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -476,7 +476,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="entry_name_errors" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="entry_name_errors" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     <ul class="m-0">
                                                     {% for error in comm_form.entry_name.errors %}
                                                         <li>{{ error|escape }}</li>
@@ -541,7 +541,7 @@
                                                 <script>
                                                     sessionStorage.setItem("allChecks", "fail");
                                                 </script>
-                                                <div id="polygon_missing" class="alert alert-danger alert-dismissible fade show form-error" role="alert">
+                                                <div id="polygon_missing" class="alert alert-danger django-alert alert-dismissible fade show form-error" role="alert">
                                                     {% if LANGUAGE_CODE == 'en' %}
                                                     You need to draw a polygon to submit the form.
                                                     {% elif LANGUAGE_CODE == 'es' %}


### PR DESCRIPTION
Closes #103. Closes #111. Closes #105.

A few form validation changes:

- If the user enters a polygon correctly but makes a mistake in another field the map will redraw the polygon, highlight the right blocks, and zoom into the right state. Uses sessionStorage to remember the state found by the user via the geocoder.
- Added form entry errors on all fields using alerts.
- Added red borders to fields in order highlight fields missed by the user.
- FIXES error on pressing "Draw" again. In the past, if user pressed draw, the polygon would disappear but that wouldn't update the entry. Thus, it was possible for the user to submit the wrong polygon if they didn't pay attention.

How to test:

- Try to leave a field non filled. The border should turn red.
- Draw a polygon but DONT fill any of the interests fields. This will trigger an error but will attempt to submit the form. Then you can observe the map behavior.
- Draw a polygon. Then press on "Draw polygon" again. Try to submit form. It should not let you.

One screenshot (hard to replicate other behavior):
<img width="1074" alt="Screen Shot 2020-05-25 at 23 21 19" src="https://user-images.githubusercontent.com/8714338/82858522-1d530900-9ee2-11ea-95fe-e4377d363cf6.png">
