### PR TITLE
dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.7-slim
+
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir /code
+
+WORKDIR /code
+EXPOSE 8000
+
+RUN BUILD_DEPS=" \
+        build-essential \
+        libpcre3-dev \
+        libpq-dev \
+        gdal-bin \
+        wget \
+        git \
+        libsqlite3-dev \
+        zlib1g-dev \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS
+
+RUN git clone https://github.com/mapbox/tippecanoe.git && cd tippecanoe && make -j && make install
+
+# RUN pip install --upgrade pip
+
+# COPY requirements.txt /code/
+# RUN pip install -r /code/requirements.txt 
+COPY . /code/
+RUN set -ex \
+    pip install --upgrade pip \
+    && pip install -r requirements.txt
+    # && pip install virtualenv --user \
+    # && virtualenv venv \
+    # && . venv/bin/activate \
+    # && pip install -r requirements.txt
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.1"
+
+services:
+  db:
+    image: "kartoza/postgis:11.0-2.5"
+    hostname: "db"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: representable333
+      POSTGRES_USER: representable
+      POSTGRES_DB: representable_db
+  django:
+    build: .
+    command: python ./manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    environment:
+      - DISTR_DB_NAME
+      - DISTR_DB_USER
+      - DISTR_DB_PASS
+      - DISTR_MAPBOX_KEY
+      - DJANGO_SETTINGS_MODULE
+      - SECRET_KEY
+    depends_on:
+      - db

--- a/representable/settings/base.py
+++ b/representable/settings/base.py
@@ -140,7 +140,9 @@ else:
             "ENGINE": "django.contrib.gis.db.backends.postgis",
             "NAME": os.environ.get("DISTR_DB_NAME", ""),
             "USER": os.environ.get("DISTR_DB_USER", ""),
-            "PASS": os.environ.get("DISTR_DB_PASS", ""),
+            "PASSWORD": os.environ.get("DISTR_DB_PASS", ""),
+            "HOST": "db",
+            "PORT": "5432",
         }
     }
 


### PR DESCRIPTION
**don't merge this until we're sure it works!** 

to run this you'll need:

- a copy of Docker Desktop https://www.docker.com/get-started

then to get the app running, I've done the following steps:


1. `heroku pg:backups:capture -a representable` (generates a new backup of prod db)
2. `heroku pg:backups:download -a representable` (downloads the latest backup)
3. `docker-compose up db` (starts the db)
4. `pg_restore --verbose --clean --no-acl --no-owner -h localhost -U representable -d representable_db latest.dump` (restores the downloaded db copy into the db)
5. `docker-compose up django` (i've been running this in a terminal window separate from the one i run step (3) in — there is a way to make Docker recognize that there is a dependency between them but I could not get it to work properly. This was the simplest way to get it working for me)

for subsequent runs you should only need to do steps (3) and (5)