### PR TITLE
Add multi-entry export functionality in Django Admin

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -33,6 +33,7 @@ class CommunityResource(resources.ModelResource):
         fields = (
             "id",
             "user_name",
+            "user__email",
             "entry_name",
             "cultural_interests",
             "economic_interests",
@@ -44,6 +45,7 @@ class CommunityResource(resources.ModelResource):
         export_order = (
             "id",
             "user_name",
+            "user__email",
             "entry_name",
             "cultural_interests",
             "economic_interests",

--- a/main/admin.py
+++ b/main/admin.py
@@ -19,6 +19,54 @@
 #
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from import_export import resources
+from import_export.admin import ImportExportModelAdmin
+from main.models import CommunityEntry
 from .models import User
 
 admin.site.register(User, UserAdmin)
+
+
+class CommunityResource(resources.ModelResource):
+    class Meta:
+        model = CommunityEntry
+        fields = (
+            "id",
+            "user_name",
+            "entry_name",
+            "cultural_interests",
+            "economic_interests",
+            "comm_activities",
+            "user_polygon",
+            "census_blocks_polygon",
+            "created_at",
+        )
+        export_order = (
+            "id",
+            "user_name",
+            "entry_name",
+            "cultural_interests",
+            "economic_interests",
+            "comm_activities",
+            "created_at",
+            "user_polygon",
+            "census_blocks_polygon",
+        )
+
+
+class CommunityAdmin(ImportExportModelAdmin):
+    list_display = (
+        "id",
+        "user_name",
+        "entry_name",
+        "organization",
+        "campaign",
+    )
+    list_filter = (
+        "campaign",
+        "organization",
+    )
+    resource_class = CommunityResource
+
+
+admin.site.register(CommunityEntry, CommunityAdmin)

--- a/representable/settings/base.py
+++ b/representable/settings/base.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.sites",
     "django.contrib.staticfiles",
+    "import_export",
     "main",
     "leaflet",
     "django_select2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,4 @@ Werkzeug==0.15.4
 whitenoise==4.1.2
 wrapt==1.11.2
 django-phone-field==1.8.0
+django-import-export==2.2.0


### PR DESCRIPTION
Opening this issue to resolve #213 : we need a way to share the results of this round of testing with partners. The easiest way to do this seems to be from Django admin so that's what I decided to try.

Key Changes:
- Registers CommunityEntry model in Django Admin
- Sets up django import export to export communities
- Optionally filter communities by organization

To test:
- Create a super user (or log in with one)
- Login to django admin at localhost_url/admin
- Click on community entrys (should be spelled entries - but the plural was set automatically)
- try filtering by community and org
- see that export works for xlsx (excel), and json

Notes:
- CSV export not working properly because polygons are not easily serialized in CSVs. I think this is fine because we can export properly in excel and json. 

Screenshots:
<img width="1434" alt="Screen Shot 2020-06-14 at 2 10 45 PM" src="https://user-images.githubusercontent.com/8892509/84604268-9a223480-ae49-11ea-9490-0778e55765ef.png">
<img width="1416" alt="Screen Shot 2020-06-14 at 2 10 55 PM" src="https://user-images.githubusercontent.com/8892509/84604267-94c4ea00-ae49-11ea-8e27-a526c94fb32b.png">
<img width="1397" alt="Screen Shot 2020-06-14 at 2 11 12 PM" src="https://user-images.githubusercontent.com/8892509/84604266-91c9f980-ae49-11ea-9c5f-0521ff1c5559.png">
<img width="652" alt="Screen Shot 2020-06-15 at 5 40 29 PM" src="https://user-images.githubusercontent.com/8892509/84719180-80f3b380-af2f-11ea-90e1-078be4649f23.png">

