### PR TITLE
[Draft] gmail-based email verification

### DIFF
--- a/representable/settings/base.py
+++ b/representable/settings/base.py
@@ -234,6 +234,8 @@ elif DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
         "ENGINE"
     ] = "django.contrib.gis.db.backends.spatialite"
 
+ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/representable/settings/base.py
+++ b/representable/settings/base.py
@@ -234,8 +234,13 @@ elif DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
         "ENGINE"
     ] = "django.contrib.gis.db.backends.spatialite"
 
-# Can Log In With Either Email or Username
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
-
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
-DEFAULT_FROM_EMAIL = "no-reply@representable.org"
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+EMAIL_USE_TLS = True
+EMAIL_HOST = "smtp.gmail.com"  # I used gmail in my case
+EMAIL_HOST_USER = "representableteam@gmail.com"
+EMAIL_HOST_PASSWORD = os.environ.get("GMAIL_PASS")
+EMAIL_PORT = 587
+DEFAULT_FROM_EMAIL = "representableteam@gmail.com"

--- a/representable/settings/dev.py
+++ b/representable/settings/dev.py
@@ -6,6 +6,6 @@ SECURE_SSL_REDIRECT = False
 
 DEBUG = True
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 MIXPANEL_TOKEN = "ce31fc3e8e15a16619bb3672f9c25407"

--- a/representable/settings/prod.py
+++ b/representable/settings/prod.py
@@ -10,14 +10,4 @@ ALLOWED_HOSTS = ["www.representable.org", "representable.org"]
 
 DEBUG = False
 
-ACCOUNT_EMAIL_VERIFICATION = "mandatory"
-
-ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 7
-SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
-EMAIL_HOST = "smtp.sendgrid.net"
-EMAIL_HOST_USER = "apikey"
-EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-
 MIXPANEL_TOKEN = "d0cc0bfda7587bccdb286d10deeac993"


### PR DESCRIPTION
Edward and Theo - not sure if this is super helpful to y'all but since Sendgrid has been throttling emails, I figured it might be best to just send emails straight from gmail - it seems that many people have used gmail as a way to avoid paying for email verification before anyways.

Key changes:
- Uses gmail to send email rather than send grid
- Moves all email settings into base.py (we would verify the same way in prod vs local)

To replicate:
- First, add our gmail password to your .bash_profile. You can find the gmail password in our Bitwarden.

Run nano ~/.bash_profile

Add the following line:
```
export GMAIL_PASS="..."
```

- Next, create an account using a valid email. 
- See that a real email appears in your inbox and click on the verification email.
- Sign in with your verified account.
