### PR TITLE
Entry form edits; smaller form size

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -82,11 +82,11 @@ class CommunityForm(ModelForm):
             "entry_name": forms.TextInput(
                 attrs={"placeholder": "Community Name"}
             ),
-            "entry_reason": forms.Textarea(attrs={"rows": 5}),
-            "cultural_interests": forms.Textarea(attrs={"rows": 5}),
-            "economic_interests": forms.Textarea(attrs={"rows": 5}),
-            "comm_activities": forms.Textarea(attrs={"rows": 5}),
-            "other_considerations": forms.Textarea(attrs={"rows": 5}),
+            "entry_reason": forms.Textarea(attrs={"rows": 3}),
+            "cultural_interests": forms.Textarea(attrs={"rows": 3}),
+            "economic_interests": forms.Textarea(attrs={"rows": 3}),
+            "comm_activities": forms.Textarea(attrs={"rows": 3}),
+            "other_considerations": forms.Textarea(attrs={"rows": 3}),
             "user_name": forms.TextInput(attrs={"placeholder": "Full Name"}),
             "user_polygon": forms.HiddenInput(),
         }

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -311,8 +311,7 @@
                                         </div> -->
                                         <p class="card-text mb-0">
                                             Is there a shared economy in the geographic area of your community?
-                                            How and where are residents employed? What parts of a county,
-                                            township or city are included in your community?
+                                            How and where are residents employed?
                                             Are there shared environmental concerns such as landfills or water quality?
                                         </p>
                                         <div class="accordion" id="economic_interests_accordion">


### PR DESCRIPTION
Edits to make the community interest boxes less intimidating / more user friendly.
1) Shrunk box size from 5 lines to 3 lines
2) Slight edit to economic interest prompt such that all question prompts are now 1 or 2 lines.

To Replicate:
python manage.py runserver
Visit entry page