### PR TITLE
state template formatting updates

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -444,6 +444,7 @@ color scheme. See readme.md*/
 .state {
   max-width: 70%;
   height: 50vh;
+  margin: auto;
 }
 .state-sm {
   width: 2rem;
@@ -854,7 +855,7 @@ label {
 .card-signin {
   border: 0;
   border-radius: 1rem;
-  box-shadow: 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.3rem 0.6rem 0 rgba(0, 0, 0, 0.1);
 }
 
 .card-signin .card-title {

--- a/main/templates/main/state.html
+++ b/main/templates/main/state.html
@@ -10,9 +10,6 @@
   <div class="row row-hero my-5">
     <div class="col-12">
       <h1 class="font-weight-light text-center mb-3">Welcome to {{ state_obj.name }}
-        {% with "img/states/"|add:state_obj.abbr|add:".svg" as svg %}
-              <object type="image/svg+xml" class="state-sm" data="{% static svg %}"></object>
-        {% endwith %}
       </h1>
     </div>
   </div>
@@ -47,8 +44,8 @@
     </div>
   </div>
   <div class="jumbotron">
-    <div class="px-5">
-      <h5 class="mt-3">Communities of Interest</h5>
+    <div>
+      <h5>Communities of Interest</h5>
       {% autoescape off %}
       {{ state_obj.content_coi }}
       {% endautoescape %}
@@ -56,7 +53,7 @@
   </div>
   <div class="card card-signin my-3">
     <div class="card-body">
-      <h2 class="font-weight-light">Community Mapping Drives in {{ state_obj.name }}</h2>
+      <h2 class="font-weight-light text-center">Community Mapping Drives in {{ state_obj.name }}</h2>
       <p>Organizations in {{ state_obj.name }} are running community mapping drives to collect information so your community's interests can be protected. You can use Representable to submit your community's information directly to these organizations.</p>
       {% if drives %}
         <hr>
@@ -85,7 +82,7 @@
           <h5 class="font-weight-light my-3">If you would like to create your own community independently of a partner organization, you can draw and export your community here.</h5>
         </div>
         <div class="col-sm-3">
-          <a class="btn ws-normal btn-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}" role="button">Draw my community</a>
+          <a class="btn ws-normal btn-outline-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}" role="button">Draw my community</a>
         </div>
       </div>
     </div>

--- a/main/templates/main/state.html
+++ b/main/templates/main/state.html
@@ -9,7 +9,7 @@
 <div class="container">
   <div class="row row-hero my-5">
     <div class="col-12">
-      <h1 class="font-weight-light text-center mb-3">Welcome to {{ state_obj.name }}!
+      <h1 class="font-weight-light text-center mb-3">Welcome to {{ state_obj.name }}
         {% with "img/states/"|add:state_obj.abbr|add:".svg" as svg %}
               <object type="image/svg+xml" class="state-sm" data="{% static svg %}"></object>
         {% endwith %}
@@ -24,11 +24,11 @@
       {% endautoescape %}
     </div>
     <div class="col-6 d-none d-sm-block">
-      <div class="text-center">
       {% with "img/states/"|add:state_obj.abbr|add:".svg" as svg %}
-      <object type="image/svg+xml" class="state" data="{% static svg %}"></object>
-      {% endwith %}
+      <div class="card card-signin mx-auto h-100 py-4">
+        <object type="image/svg+xml" class="state h-100" data="{% static svg %}"></object>
       </div>
+      {% endwith %}
     </div>
   </div>
 
@@ -46,8 +46,8 @@
       </div>
     </div>
   </div>
-  <div class="row bg-light">
-    <div class="col-12 px-5">
+  <div class="jumbotron">
+    <div class="px-5">
       <h5 class="mt-3">Communities of Interest</h5>
       {% autoescape off %}
       {{ state_obj.content_coi }}
@@ -68,7 +68,7 @@
           <p>{{ drive.description }}</p>
           </div>
           <div class="col-sm-3">
-            <a class="btn btn-outline-primary" href="{% url 'main:entry' drive=drive.slug %}">Join Drive</a>
+            <a class="btn btn-lg btn-primary" href="{% url 'main:entry' drive=drive.slug %}">Join Drive</a>
           </div>
         </div>
         <hr>


### PR DESCRIPTION
**changes**
- responsiveness of state svg (wrapped in card)
- removed exclamation point
- jumbotron w/ rounded edges for COI section
- join drive button larger + primary coloring
- reduced drop shadow of cards

**to test**
1. go to state page
2. play w responsiveness

**of note**
- please comment any additional thoughts on formatting -- this is all easy stuff to change (for the most part)
- in the future, i think it would be great to have some themed drawings of some sort, like we have on the landing page
- maybe we want to de-emphasize the final "draw my community" button by making it an outline

**screenshot**
![image](https://user-images.githubusercontent.com/41943646/87268045-bbd80f80-c50c-11ea-8f19-9ca40821218d.png)
