### PR TITLE
Add info to partner page, auto email when org is created

### DIFF
--- a/main/templates/main/partners/get_started.html
+++ b/main/templates/main/partners/get_started.html
@@ -7,9 +7,10 @@
     <div class="col-lg-6 text-center my-5 order-md-1">
       <h1 class="font-weight-light"> Partner With Us</h1>
       <p class="font-weight-light">
-        Welcome to Representable! Request early access to create an organization below.
+        Welcome to Representable! Get started by creating an organization or requesting a demo below.
       </p>
-      <a class="btn btn-primary" href="mailto:team@representable.org?subject=Early%20Access&body=Dear%20Representable%20Team%2C%0D%0A%0D%0AI'd%20like%20to%20request%20early%20access%20to%20organization%20features%20on%20behalf%20of%20______." role="button">Request Early Access</a>
+      <a class="btn btn-primary" href="{% url 'main:create_org' %}" role="button">Get Started</a>
+      <a class="btn btn-outline-primary" href="mailto:team@representable.org?subject=Representable%20Demo&body=Dear%20Representable%20Team%2C%0D%0A%0D%0AI'd%20like%20to%20request%20a%20product%20demo%20on%20behalf%20of%20______." role="button">Request Demo</a>
       <img class="img-fluid align-bottom" src="{% static 'img/illustration.svg' %}"></img>
     </div>
     <div class="col-lg-6 order-md-2">
@@ -18,17 +19,17 @@
           <h5><span class="badge badge-primary">1</span> Create an Organization</h5>
           <p>Include a brief description, link, and the state(s) you operate in.</p>
           <hr>
-          <h5><span class="badge badge-primary">2</span> Upload an Email List to Pre-Approve Submissions</h5>
-          <p>By uploading a .csv file of emails in your organization, you can automatically approve submissions from your members.</p>
+          <h5><span class="badge badge-primary">2</span> Start a Community Mapping Drive</h5>
+          <p>Create a community mapping drive via the dashboard and share the link via email and social media to individuals in your state.</p>
           <hr>
-          <h5><span class="badge badge-primary">3</span> Manage Membership</h5>
-          <p>Designate users as admins on your organization dashboard.</p>
-          <hr>
-          <h5><span class="badge badge-primary">4</span> Moderate Submissions</h5>
+          <h5><span class="badge badge-primary">3</span> Moderate Community Submissions</h5>
           <p>Review communities submitted under your organization.</p>
           <hr>
-          <h5><span class="badge badge-primary">5</span> View Your Map</h5>
+          <h5><span class="badge badge-primary">4</span> Visualize a Map of Submissions</h5>
           <p>View a map of all the communities submitted to your organization together.</p>
+          <hr>
+          <h5><span class="badge badge-primary">5</span> Export Community Submissions</h5>
+          <p>Download all the communities submitted to your organization as geoJSON for easy integration with district drawing and visualization tools.</p>
         </div>
       </div>
     </div>

--- a/main/templates/main/partners/get_started.html
+++ b/main/templates/main/partners/get_started.html
@@ -20,10 +20,10 @@
           <p>Include a brief description, link, and the state(s) you operate in.</p>
           <hr>
           <h5><span class="badge badge-primary">2</span> Start a Community Mapping Drive</h5>
-          <p>Create a community mapping drive via the dashboard and share the link via email and social media to individuals in your state.</p>
+          <p>Create a community mapping drive via the organization dashboard. </p>
           <hr>
-          <h5><span class="badge badge-primary">3</span> Moderate Community Submissions</h5>
-          <p>Review communities submitted under your organization.</p>
+          <h5><span class="badge badge-primary">3</span> Share your Mapping Drive</h5>
+          <p>Share the link to your community mapping drive via email and social media to individuals in your state to start collecting submissions.</p>
           <hr>
           <h5><span class="badge badge-primary">4</span> Visualize a Map of Submissions</h5>
           <p>View a map of all the communities submitted to your organization together.</p>

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -28,6 +28,7 @@ from django.views.generic import (
     DeleteView,
 )
 from django.views import View
+from django.core.mail import send_mail
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from allauth.account.decorators import verified_email_required
 from ..forms import (
@@ -134,6 +135,25 @@ class CreateOrg(LoginRequiredMixin, CreateView):
         # by default, make the user creating the org the admin
         admin = Membership(member=self.request.user, organization=org,)
         admin.save()
+
+        email_content = (
+            "Dear Representable Team, "
+            + self.request.user.username
+            + " signed up to create an organization called "
+            + org.name
+            + "."
+            + " You can follow up via email at : "
+            + self.request.user.email
+            + "!"
+        )
+
+        send_mail(
+            "[Action Required] New Organization Sign-up",
+            email_content,
+            "no-reply@representable.org",
+            ["team@representable.org"],
+            fail_silently=False,
+        )
 
         self.success_url = reverse_lazy(
             "main:thanks_org", kwargs=org.get_url_kwargs()


### PR DESCRIPTION
Key Changes:
- Simplified org creation flow by remove request access. Now it's get started (takes you to org creation form) and request demo (for those who aren't sure yet). 
- Automatically emails team@representable.org when a user has created an org. 
- Includes user details in email (see screenshots) for easy follow up
- Updated info on partner page to reflect community mapping drives

To test:
- I tested this by checking the email in the console after creating an org at: http://127.0.0.1:8000/dashboard/partners/create/ 
- I also tried moving email settings from prod.py to base.py to make sure the email would actually send and it did for me.
- Play around with button behavior, review content at: http://127.0.0.1:8000/partners/welcome/

Screenshots:
<img width="1082" alt="Screen Shot 2020-07-22 at 12 13 53 PM" src="https://user-images.githubusercontent.com/8892509/88218632-26780200-cc15-11ea-998b-b3d53bed6029.png">
<img width="672" alt="Screen Shot 2020-07-22 at 11 50 28 AM" src="https://user-images.githubusercontent.com/8892509/88218638-2841c580-cc15-11ea-934d-226824c7f7f9.png">
