### PR TITLE
chicago ward + community area data

### DIFF
--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -163,6 +163,8 @@ var BG_KEYS = {
   "txbg": "5x05l0of",
   "vabg": "3pmrtqs2",
 };
+var CHI_WARD_KEY = "179v2oeh";
+var CHI_COMM_KEY = "63nswxfc";
 // var states = [
 //   "ak",
 //   "al",

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -35,6 +35,8 @@ var geocoder = new MapboxGeocoder({
 });
 map.addControl(geocoder, "top-right");
 
+state = state.toLowerCase();
+
 // Add geolocate control to the map. -- this zooms in on the user's current location when pressed
 // Q: is it too confusing ? like the symbol doesn't exactly tell you what it does
 map.addControl(
@@ -60,10 +62,10 @@ function newSourceLayer(name, mbCode) {
 function newCensusLayer(state, firstSymbolId) {
   map.addLayer(
     {
-      id: state.toUpperCase() + " Census Blocks",
+      id: state.toUpperCase() + " Census Blockgroups",
       type: "line",
-      source: state + "-census",
-      "source-layer": state + "census",
+      source: state + "bg",
+      "source-layer": state + "bg",
       layout: {
         visibility: "none",
       },
@@ -125,27 +127,73 @@ map.on("load", function () {
     }
   }
   // this is where the census blocks are loaded, from a url to the mbtiles file uploaded to mapbox
-  for (let census in CENSUS_KEYS) {
-    newSourceLayer(census, CENSUS_KEYS[census]);
-  }
-  // upper layers
-  for (let upper in UPPER_KEYS) {
-    if (states[i] !== "dc") {
-      newSourceLayer(upper, UPPER_KEYS[upper]);
+  if (state === ""){
+    for (let bg in BG_KEYS) {
+      newSourceLayer(bg, BG_KEYS[bg]);
     }
-  }
-  // lower layers
-  for (let lower in LOWER_KEYS) {
-    if (states[i] !== "dc") {
-      newSourceLayer(lower, LOWER_KEYS[lower]);
+    // upper layers
+    for (let upper in UPPER_KEYS) {
+      if (states[i] !== "dc") {
+        newSourceLayer(upper, UPPER_KEYS[upper]);
+      }
     }
-  }
-  for (let i = 0; i < states.length; i++) {
-    newCensusLayer(states[i], firstSymbolId);
-    if (states[i] !== "dc") {
-      newUpperLegislatureLayer(states[i]);
-      newLowerLegislatureLayer(states[i]);
+    // lower layers
+    for (let lower in LOWER_KEYS) {
+      if (states[i] !== "dc") {
+        newSourceLayer(lower, LOWER_KEYS[lower]);
+      }
     }
+    for (let i = 0; i < states.length; i++) {
+      newCensusLayer(states[i], firstSymbolId);
+      if (states[i] !== "dc") {
+        newUpperLegislatureLayer(states[i]);
+        newLowerLegislatureLayer(states[i]);
+      }
+    }
+  } else {
+    newSourceLayer(state + "bg", BG_KEYS[state + "bg"]);
+    newSourceLayer(state + "-upper", UPPER_KEYS[state + "-upper"]);
+    newSourceLayer(state + "-lower", LOWER_KEYS[state + "-lower"]);
+    newCensusLayer(state, firstSymbolId);
+    newUpperLegislatureLayer(state);
+    newLowerLegislatureLayer(state);
+  }
+  // ward + community areas for IL
+  if (state === "il") {
+    newSourceLayer("chi_wards", CHI_WARD_KEY);
+    newSourceLayer("chi_comm", CHI_COMM_KEY);
+    map.addLayer(
+      {
+        id: "Chicago Wards",
+        type: "line",
+        source: "chi_wards",
+        "source-layer": "chi_wards",
+        layout: {
+          visibility: "none",
+        },
+        paint: {
+          "line-color": "rgba(106,137,204,0.3)",
+          "line-width": 1,
+        },
+      },
+      firstSymbolId
+    );
+    map.addLayer(
+      {
+        id: "Chicago Community Areas",
+        type: "line",
+        source: "chi_comm",
+        "source-layer": "chi_comm",
+        layout: {
+          visibility: "none",
+        },
+        paint: {
+          "line-color": "rgba(106,137,204,0.3)",
+          "line-width": 1,
+        },
+      },
+      firstSymbolId
+    );
   }
   map.addSource("counties", {
     type: "vector",
@@ -283,7 +331,7 @@ map.on("load", function () {
   // fly to state if org, otherwise stay on map
   if (state !== "") {
     map.flyTo({
-      center: statesLngLat[state],
+      center: statesLngLat[state.toUpperCase()],
       zoom: 5,
       essential: true // this animation is considered essential with respect to prefers-reduced-motion
     });
@@ -312,11 +360,16 @@ document.querySelectorAll(".comm-content").forEach(function (p) {
 
 //create a button that toggles layers based on their IDs
 var toggleableLayerIds = [
-  "Census Blocks",
+  "Census Blockgroups",
   "State Legislature - House/Assembly",
   "State Legislature - Senate",
   "counties"
 ];
+// add selector for chicago wards + community areas if illinois
+if (state === "il") {
+  toggleableLayerIds.push("Chicago Wards");
+  toggleableLayerIds.push("Chicago Community Areas");
+}
 
 for (var i = 0; i < toggleableLayerIds.length; i++) {
   var id = toggleableLayerIds[i];
@@ -335,9 +388,18 @@ for (var i = 0; i < toggleableLayerIds.length; i++) {
     if (txt === "counties") {
       clickedLayers.push("counties");
     } else {
-      for (let i = 0; i < states.length; i++) {
-        if (states[i] !== "dc" || txt === "Census Blocks") {
-          clickedLayers.push(states[i].toUpperCase() + " " + txt);
+      if (state === "") {
+        for (let i = 0; i < states.length; i++) {
+          if (states[i] !== "dc" || txt === "Census Blocks") {
+            clickedLayers.push(states[i].toUpperCase() + " " + txt);
+          }
+        }
+      }
+      else {
+        if (state === "il" && (txt === "Chicago Wards" || txt === "Chicago Community Areas")) {
+          clickedLayers.push(txt);
+        } else {
+          clickedLayers.push(state.toUpperCase() + " " + txt);
         }
       }
     }

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -48,8 +48,8 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                 {% endif %}
               </div>
               <div class="row justify-content-center">
-                <a class="btn btn-outline-primary btn-canvas mx-auto" href={{multi_export_link}} role="button" download="communities.geojson">Export GeoJSON</a>
-              </div>              
+                <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto" href={{multi_export_link}} role="button" download="communities.geojson">Export GeoJSON</a>
+              </div>
               <div id="headingOne">
                 <button class="viz-dropdown btn btn-light font-weight-light" type="button" data-toggle="collapse" data-target="#collapseOne"
                 aria-expanded="false" aria-controls="collapseOne" style="width: 100%">

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -93,7 +93,7 @@ class PartnerMap(TemplateView):
         }
         org = Organization.objects.get(slug=self.kwargs["slug"])
         context["organization"] = org
-        context["state"] = org.states[0]
+        context["state"] = org.states[0].lower()
         if not self.kwargs["drive"]:
             context["multi_export_link"] = (
                 "/multiexport/org/" + self.kwargs["slug"]


### PR DESCRIPTION
closes #265 

** changes **
- added ward + community area files to mapbox tilesets
- display Chicago ward + community outlines on map views for illinois only
- map views only show state specific layers for org/drive views now (instead of all)

** to test **
- create an illinois organization/drive
- go to map page
- under "data layers" select "chicago wards" or "chicago community areas"

** screenshots**
![image](https://user-images.githubusercontent.com/41943646/88361911-059ee080-cdbe-11ea-9fdf-35b361de57fa.png)
