### PR TITLE
Email Verification in Organization Flow

### DIFF
--- a/main/fixtures/single_org.json
+++ b/main/fixtures/single_org.json
@@ -78,5 +78,15 @@
       "created_at": "2020-06-26T00:36:52.834Z",
       "is_active": true
     }
+  },
+  {
+    "model": "account.emailaddress",
+    "pk": 1,
+    "fields": {
+      "email": "test@me.com",
+      "verified": true,
+      "primary": true,
+      "user_id": 1
+    }
   }
 ]

--- a/main/templates/main/dashboard/drives/create.html
+++ b/main/templates/main/dashboard/drives/create.html
@@ -8,9 +8,10 @@
         <div class="col-sm-9 col-md-7 col-lg-5 mx-auto">
             <div class="card card-signin my-5">
                 <div class="card-body">
+                    {% if verified %}
                     <h5 class="card-title text-center">
                         Create a Drive
-                      </h5>
+                    </h5>
                       <form role="form" id="CreateDrive" method="post">{% csrf_token %}
 
                           <div class="form-group">
@@ -28,6 +29,19 @@
                           <button id="save" form="CreateDrive" type="submit" class="btn btn-primary" value="Submit">Submit</button>
                       </div>
                       </form>
+                    {% endif %}
+                    {% if not verified %}
+                    <h5 class="card-title text-center">
+                        Create a Drive
+                    </h5>
+
+                    <p class = "text-center"> Please first verify your email. Email verification is necessary
+                        to access this feature on Representable. </p>
+                    <p class = "text-center"> We have resent an email verification link to your inbox. Please don't
+                    hesitate to reach out to us at team@representable.org with any questions.
+                    </p>
+                    {% endif %}
+
                 </div>
             </div>
         </div>

--- a/main/templates/main/dashboard/partners/thanks.html
+++ b/main/templates/main/dashboard/partners/thanks.html
@@ -9,14 +9,24 @@
             <div class="card card-signin my-5">
                 <div class="card-body">
                     <h5 class="card-title text-center">
-                        {% if LANGUAGE_CODE == 'en' %}
+                        {% if verified %}
                             Thank you for creating an organization!
-                        {% elif LANGUAGE_CODE == 'es' %}
+                        {% endif %}
+
+                        {% if not verified %}
+                        <p> Please verify your email. </p>
+                        {% endif %}
+
+                        {% if LANGUAGE_CODE == 'es' %}
                               <!-- Google translate  -->
                               ¡Gracias por enviar su organización!
                         {% endif %}
                     </h5>
                     <p class="text-center">We are excited to work with you to create high-quality maps of communities of interest.</p>
+                    {% if not verified %}
+                    <p class = "text-center"> Email verification will be necessary
+                        to access certain organization features on Representable. We have resent an email verification link to your inbox.</p>
+                    {% endif %}
                     <div class="text-center"> <a class="btn btn-primary btn-canvas font-weight-light text-uppercase" href="{% url 'main:home_org' view.kwargs.slug  view.kwargs.pk %}" role="button"><small>organization dashboard</small></a>
                     </div>
                 </div>

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -195,7 +195,6 @@ class ThanksOrg(LoginRequiredMixin, TemplateView):
             user=self.request.user, verified=True
         ).exists()
 
-        print(context)
         return context
 
 
@@ -447,6 +446,26 @@ class CreateDrive(LoginRequiredMixin, OrgAdminRequiredMixin, CreateView):
     template_name = "main/dashboard/drives/create.html"
     form_class = DriveForm
     pk_url_kwarg = "cam_pk"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        if not EmailAddress.objects.filter(
+            user=self.request.user, verified=True
+        ).exists():
+            user_email_address = EmailAddress.objects.get(
+                user=self.request.user
+            )
+            user_email_confirmation = EmailConfirmationHMAC(
+                email_address=user_email_address
+            )
+            user_email_confirmation.send(self.request, False)
+
+        context["verified"] = EmailAddress.objects.filter(
+            user=self.request.user, verified=True
+        ).exists()
+
+        return context
 
     def form_valid(self, form):
         # TODO: include a check to make sure this actually the user's org

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -30,7 +30,11 @@ from django.views.generic import (
 from django.views import View
 from django.core.mail import send_mail
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from allauth.account.decorators import verified_email_required
+from allauth.account.models import (
+    EmailConfirmation,
+    EmailAddress,
+    EmailConfirmationHMAC,
+)
 from ..forms import (
     CommunityForm,
     DriveForm,
@@ -159,6 +163,18 @@ class CreateOrg(LoginRequiredMixin, CreateView):
             "main:thanks_org", kwargs=org.get_url_kwargs()
         )
 
+        if not EmailAddress.objects.filter(
+            user=self.request.user, verified=True
+        ).exists():
+
+            user_email_address = EmailAddress.objects.get(
+                user=self.request.user
+            )
+            user_email_confirmation = EmailConfirmationHMAC(
+                email_address=user_email_address
+            )
+            user_email_confirmation.send(self.request, False)
+
         return super().form_valid(form)
 
 
@@ -171,6 +187,16 @@ class ThanksOrg(LoginRequiredMixin, TemplateView):
     """
 
     template_name = "main/dashboard/partners/thanks.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["verified"] = EmailAddress.objects.filter(
+            user=self.request.user, verified=True
+        ).exists()
+
+        print(context)
+        return context
 
 
 class EditOrg(LoginRequiredMixin, OrgAdminRequiredMixin, UpdateView):


### PR DESCRIPTION
**Changes**:

1) When an organization is created with a not verified account: Resends verification email link, displays modified message  "please verify account, email verification is necessary for certain features ..."

2) When a not verified account attempts to create a community drive: Does not let the account create a drive, displays message "email verification is necessary to access this feature ...", Resends a verification link.

**To test**

Make an organization with a not verified email account.
Check to see verification link is resent.
Check to see that a modified message is displayed.

Try creating a community drive with a not verified email account
Check to see verification link is resent.
Check to see that the following modified page is displayed instead of the Create a Drive form.

<img width="1055" alt="Screen Shot 2020-07-27 at 3 20 56 PM" src="https://user-images.githubusercontent.com/13109022/88582568-ece03600-d01c-11ea-8521-0fadba8a0871.png">
11ea-91a5-8746cd7cd626.png">


