### PR TITLE
Entry State Views Setup

### DIFF
--- a/main/templates/main/dashboard/drives/index.html
+++ b/main/templates/main/dashboard/drives/index.html
@@ -49,7 +49,7 @@
             <li class="list-group-item d-flex justify-content-between align-items-center">
               <div>
                 <h5><span class="badge badge-secondary"><i class="fas fa-share-alt"></i></span> Gather Submissions</h5>
-                <p>Gather submissions for this drive! Copy this link and share it with people you'd like to contribute to this drive: <a href="{% url 'main:drive_page' object.slug %}">representable.org{% url 'main:drive_page' object.slug %}</a></p>
+                <p>Gather submissions for this drive! Copy this link and share it with people you'd like to contribute to this drive: <a href="{% url 'main:drive_page' object.slug %}{{object.state}">representable.org{% url 'main:drive_page' object.slug %}</a></p>
               </div>
               <a class="btn btn-primary" href="{% url 'main:drive_page' object.slug %}" role="button">View <i class="fa fa-arrow-circle-right"></i></a>
             </li>

--- a/main/templates/main/drives/page.html
+++ b/main/templates/main/drives/page.html
@@ -48,7 +48,7 @@
       <p>It will provide a consistent format for Communities to use so the information will be easier for the Commission to consider in drawing the new voting district maps. </p>
       <p>Click "Draw My Community" below to share information about your Community and give your Community the voice it deserves!</p>
       {% endif %}
-        <a class="btn btn-primary btn-lg my-3 drive-new-entry" href="{% url 'main:entry' drive=object.slug %}" role="button">Draw My Community</a>
+        <a class="btn btn-primary btn-lg my-3 drive-new-entry" href="{% url 'main:entry' drive=object.slug %}{{object.state}}" role="button">Draw My Community</a>
       <!-- <a class="btn btn-outline-primary my-3" href="{% url 'main:partner_map' object.organization.slug object.slug %}" role="button">View map of communities</a> -->
     </div>
     </div>

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -35,6 +35,8 @@
     var organization_id = "{{organization_id}}";
     var drive_name = "{{drive_name}}";
     var organization_name = "{{organization_name}}";
+    var state_abbr = "{{state.abbr}}";
+    var state_name = "{{state.name}}";
     mixpanel.track("Entry Page Loaded",
     {
      "drive_id": drive_id,
@@ -96,7 +98,7 @@
                             <div class="collapse-card card-section active-section">
                                 <div class="card">
                                     <div class="card-header text-header-card">
-                                        <strong>1. Your Identifying Information</strong>
+                                        <strong>1. Your Identifying Information </strong>
                                     </div>
                                     <div class="card-body collapse show">
                                         <div class="accordion" id="privacy_accordion">

--- a/main/templates/main/state.html
+++ b/main/templates/main/state.html
@@ -65,7 +65,7 @@
           <p>{{ drive.description }}</p>
           </div>
           <div class="col-sm-3">
-            <a class="btn btn-lg btn-primary" href="{% url 'main:entry' drive=drive.slug %}">Join Drive</a>
+            <a class="btn btn-lg btn-primary" href="{% url 'main:entry' drive=drive.slug %}{{ state_obj.abbr }}">Join Drive</a>
           </div>
         </div>
         <hr>
@@ -82,7 +82,7 @@
           <h5 class="font-weight-light my-3">If you would like to create your own community independently of a partner organization, you can draw and export your community here.</h5>
         </div>
         <div class="col-sm-3">
-          <a class="btn ws-normal btn-outline-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}" role="button">Draw my community</a>
+          <a class="btn ws-normal btn-outline-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}{{state_obj.abbr}}" role="button">Draw my community</a>
         </div>
       </div>
     </div>

--- a/main/urls.py
+++ b/main/urls.py
@@ -35,6 +35,12 @@ urlpatterns = [
     path(
         "entry/drive/<slug:drive>/",
         views.main.EntryView.as_view(),
+        {"token": "", "abbr": ""},
+        name="entry",
+    ),
+    path(
+        "entry/drive/<slug:drive>/<abbr>",
+        views.main.EntryView.as_view(),
         {"token": ""},
         name="entry",
     ),
@@ -48,6 +54,18 @@ urlpatterns = [
         "entry/t/<token>/",
         views.main.EntryView.as_view(),
         {"drive": ""},
+        name="entry",
+    ),
+    path(
+        "entry/t/<token>/<abbr>/",
+        views.main.EntryView.as_view(),
+        {"drive": ""},
+        name="entry",
+    ),
+    path(
+        "entry/<abbr>/",
+        views.main.EntryView.as_view(),
+        {"token": "", "state": "", "drive": ""},
         name="entry",
     ),
     path("about/", views.main.About.as_view(), name="about"),

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -460,7 +460,15 @@ class EntryView(LoginRequiredMixin, View):
             initial.update({"user": self.request.user})
         return initial
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, abbr=None, *args, **kwargs):
+        state = None
+        if abbr:
+            statequery = State.objects.filter(abbr=abbr.upper())
+            try:
+                state = statequery[0]
+            except Exception:
+                state = None
+
         comm_form = self.community_form_class(
             initial=self.get_initial(), label_suffix=""
         )
@@ -498,6 +506,7 @@ class EntryView(LoginRequiredMixin, View):
             "organization_id": organization_id,
             "drive_name": drive_name,
             "drive_id": drive_id,
+            "state": state,
         }
         return render(request, self.template_name, context)
 


### PR DESCRIPTION
**Overview**
Setup for entry state view without any changes to geo.js. Changes to displaying the map in geo.js will be added soon in a seperate PR from a branch up upto date with the select tool.

**Changes**
Pages associated with a state now can store that information in the URL; example /entry/MI/
State pages, campaign pages, and campaign links, now link to a page with the state information.

**To Test**
Navigate through these different ways of accessing an entry page associated with a state:
1) From home page, select a state with a state page (ie. Michigan). Then click "Draw my Community. 
2) On the state page, also try clicking "Join Drive"
3) Navigate to your dashboard, create a drive, go to the entry page from that new drive.

Then check the url, to make sure that the state abbreviation is stored in the url. For example: "/entry/drive/test/AL"

**Future Changes**
Will add state association in the entry url for when clicking states on the home page dropdown that do not have a state page.
In an upcoming PR, will add the second half of this spec where map is initially displayed zoomed into the center of the associated state.

