### PR TITLE
Add confirm dialog to confirm the user wants to clear map before proceeding

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -386,10 +386,15 @@ class ClearMapButton {
     clear_button.innerHTML = "<i class='fas fa-trash-alt'></i> Clear Selection";
     this._map = map;
     clear_button.addEventListener("click", function (event) {
-      map.setFilter(state + "-bg-highlighted", ["in", "GEOID"]);
-      sessionStorage.setItem("bgFilter", "[]");
-      sessionStorage.setItem("mpoly", "[]");
-      updateCommunityEntry();
+      let isConfirmed = confirm(
+        "Are you sure you want to clear the map? This will delete the blocks you have selected."
+      );
+      if (isConfirmed) {
+        map.setFilter(state + "-bg-highlighted", ["in", "GEOID"]);
+        sessionStorage.setItem("bgFilter", "[]");
+        sessionStorage.setItem("mpoly", "[]");
+        updateCommunityEntry();
+      }
     });
     return clear_button;
   }
@@ -828,7 +833,11 @@ map.on("style.load", function () {
       }
       if (states.includes(new_state)) {
         // add block groups, remove those of previous state
-        map.setLayoutProperty(new_state + "-census-lines", "visibility", "visible");
+        map.setLayoutProperty(
+          new_state + "-census-lines",
+          "visibility",
+          "visible"
+        );
       }
       state = new_state;
     } else {
@@ -1062,19 +1071,21 @@ function updateCommunityEntry() {
 
 // check if device is touch screen --> https://stackoverflow.com/questions/4817029/whats-the-best-way-to-detect-a-touch-screen-device-using-javascript/4819886#4819886
 function is_touch_device() {
+  var prefixes = " -webkit- -moz- -o- -ms- ".split(" ");
 
-    var prefixes = ' -webkit- -moz- -o- -ms- '.split(' ');
+  var mq = function (query) {
+    return window.matchMedia(query).matches;
+  };
 
-    var mq = function (query) {
-        return window.matchMedia(query).matches;
-    }
+  if (
+    "ontouchstart" in window ||
+    (window.DocumentTouch && document instanceof DocumentTouch)
+  ) {
+    return true;
+  }
 
-    if (('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
-        return true;
-    }
-
-    // include the 'heartz' as a way to have a non matching MQ to help terminate the join
-    // https://git.io/vznFH
-    var query = ['(', prefixes.join('touch-enabled),('), 'heartz', ')'].join('');
-    return mq(query);
+  // include the 'heartz' as a way to have a non matching MQ to help terminate the join
+  // https://git.io/vznFH
+  var query = ["(", prefixes.join("touch-enabled),("), "heartz", ")"].join("");
+  return mq(query);
 }


### PR DESCRIPTION
Resolves #291 

This is a simple solution to the problem of accidentally deleting a community. I feel like it could be prettier (this could be a future PR?) but it's reliable and prevents the frustration of accidentally clearing a community

Key Changes:
- Add confirm dialog that asks user to confirm they to clear map before proceeding

To test:
- Go to entry page
- try pressing clear polygon after selecting a few blocks

Screenshots:
<img width="874" alt="Screen Shot 2020-08-04 at 11 03 25 AM" src="https://user-images.githubusercontent.com/8892509/89328664-8ffb0600-d642-11ea-8331-c4ad3d5ddafc.png">
