### PR TITLE
implement mapbox boundaries on map page

### DIFF
--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -8,13 +8,13 @@ var BOUNDARIES_ABBREV = {
 }
 
 var BOUNDARIES_LAYERS = {
-  "pos4": "5-digit Postcode Areas",
-  "loc4": "Neighborhoods",
-  "adm2": "Counties",
-  "leg4": "State House Districts",
-  "leg3": "State Senate Districts",
   "leg2": "Congressional Districts",
-  "sta5": "Census Block Group"
+  "leg3": "State Senate Districts",
+  "leg4": "State House Districts",
+  "adm2": "Counties",
+  "loc4": "Neighborhoods",
+  "pos4": "5-digit Postcode Areas",
+  "sta5": "Census Block Groups"
 }
 
 var CENSUS_KEYS = {

--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -1,3 +1,22 @@
+// used for adding the source-layer on boundaries tilesets
+var BOUNDARIES_ABBREV = {
+  "adm": "admin",
+  "pos": "postal",
+  "sta": "stats",
+  "loc": "locality",
+  "leg": "legislative"
+}
+
+var BOUNDARIES_LAYERS = {
+  "pos4": "5-digit Postcode Areas",
+  "loc4": "Neighborhoods",
+  "adm2": "Counties",
+  "leg4": "State House Districts",
+  "leg3": "State Senate Districts",
+  "leg2": "Congressional Districts",
+  "sta5": "Census Block Group"
+}
+
 var CENSUS_KEYS = {
   "ak-census": "40xiqgvl",
   "al-census": "5wnfuadx",

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -58,6 +58,27 @@ function newSourceLayer(name, mbCode) {
   });
 }
 
+// add a new mapbox boundaries source + layer
+function newBoundariesLayer(name) {
+  map.addSource(name, {
+    type: "vector",
+    url: "mapbox://mapbox.boundaries-" + name + "-v3"
+  });
+  map.addLayer(
+    {
+      id: name + "-line",
+      type: "line",
+      source: name,
+      "source-layer": "boundaries_" + BOUNDARIES_ABBREV[removeLastChar(name)] + "_" + name.slice(-1),
+      layout: {
+        visibility: "none"
+      },
+      paint: {
+        'line-color': '#CCCCCC',
+      }
+    });
+}
+
 // add a new layer of census block data
 function newCensusLayer(state, firstSymbolId) {
   map.addLayer(
@@ -195,26 +216,16 @@ map.on("load", function () {
       firstSymbolId
     );
   }
-  map.addSource("counties", {
-    type: "vector",
-    url: "mapbox://mapbox.hist-pres-election-county"
-  });
-  map.addLayer(
-    {
-      id: "counties",
-      type: "line",
-      source: "counties",
-      "source-layer": "historical_pres_elections_county",
-      layout: {
-        visibility: "none"
-      },
-      paint: {
-        "line-color": "rgba(106,137,204,0.7)",
-        "line-width": 2,
-      }
-    }
-  );
-
+  // leg2 : congressional district
+  // leg3 : state senate district
+  // leg4 : state house district
+  // adm2 : counties
+  // loc4 : neighborhoods
+  // pos4 : 5-digit postcode area
+  // sta5 : block groups
+  for (let i = 0; i < BOUNDARIES_LAYERS.length; i++) {
+    newBoundariesLayer(BOUNDARIES_LAYERS[i]);
+  }
   // send elements to javascript as geojson objects and make them show on the map by
   // calling the addTo
 
@@ -427,4 +438,10 @@ for (var i = 0; i < toggleableLayerIds.length; i++) {
   div.appendChild(label);
   layers.appendChild(div);
   var newline = document.createElement("br");
+}
+
+/*******************************************************************/
+// remove the last char in the string
+function removeLastChar(str) {
+  str.substring(0, str.length() - 1);
 }

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -138,9 +138,9 @@ map.on("load", function () {
   for (var key in BOUNDARIES_LAYERS) {
     newBoundariesLayer(key, firstSymbolId);
   }
+
   // send elements to javascript as geojson objects and make them show on the map by
   // calling the addTo
-
   var outputstr = a.replace(/'/g, '"');
   a = JSON.parse(outputstr);
 
@@ -313,10 +313,6 @@ for (var id in toggleableLayerIds){
     } else {
       map.setLayoutProperty(txt + "-lines", "visibility", "visible");
     }
-
-    // for (var j = 0; j < clickedLayers.length; j++) {
-    //
-    // }
   };
   // in order to create the buttons
   var div = document.createElement("div");

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -39,57 +39,27 @@ function newSourceLayer(name, mbCode) {
     url: "mapbox://" + mapbox_user_name + "." + mbCode,
   });
 }
-// add a new layer of census block data
-function newCensusLayer(state) {
-  map.addLayer({
-    id: state.toUpperCase() + " Census Blocks",
-    type: "line",
-    source: state + "-census",
-    "source-layer": state + "census",
-    layout: {
-      visibility: "none",
-    },
-    paint: {
-      "line-color": "rgba(106,137,204,0.3)",
-      "line-width": 1,
-    },
+// add a new mapbox boundaries source + layer
+function newBoundariesLayer(name, firstSymbolId) {
+  map.addSource(name, {
+    type: "vector",
+    url: "mapbox://mapbox.boundaries-" + name + "-v3"
   });
-}
-// add a new layer of upper state legislature data
-function newUpperLegislatureLayer(state) {
-  map.addLayer({
-    id: state.toUpperCase() + " State Legislature - Senate",
-    type: "line",
-    source: state + "-upper",
-    "source-layer": state + "upper",
-    layout: {
-      visibility: "none",
-      "line-join": "round",
-      "line-cap": "round",
+  map.addLayer(
+    {
+      id: name + "-lines",
+      type: "line",
+      source: name,
+      "source-layer": "boundaries_" + BOUNDARIES_ABBREV[removeLastChar(name)] + "_" + name.slice(-1),
+      layout: {
+        visibility: "none"
+      },
+      paint: {
+        "line-color": "rgba(106,137,204,0.7)",
+      }
     },
-    paint: {
-      "line-color": "rgba(106,137,204,0.7)",
-      "line-width": 2,
-    },
-  });
-}
-// add a new layer of lower state legislature data
-function newLowerLegislatureLayer(state) {
-  map.addLayer({
-    id: state.toUpperCase() + " State Legislature - House/Assembly",
-    type: "line",
-    source: state + "-lower",
-    "source-layer": state + "lower",
-    layout: {
-      visibility: "none",
-      "line-join": "round",
-      "line-cap": "round",
-    },
-    paint: {
-      "line-color": "rgba(106,137,204,0.7)",
-      "line-width": 2,
-    },
-  });
+    firstSymbolId
+  );
 }
 
 function sanitizePDF(x) {
@@ -102,45 +72,51 @@ function sanitizePDF(x) {
 }
 
 map.on("load", function () {
-  for (let census in CENSUS_KEYS) {
-    newSourceLayer(census, CENSUS_KEYS[census]);
+  // ward + community areas for IL
+  if (state === "il") {
+    newSourceLayer("chi_wards", CHI_WARD_KEY);
+    newSourceLayer("chi_comm", CHI_COMM_KEY);
+    map.addLayer(
+      {
+        id: "chi-ward-lines",
+        type: "line",
+        source: "chi_wards",
+        "source-layer": "chi_wards",
+        layout: {
+          visibility: "none",
+        },
+        paint: {
+          "line-color": "rgba(106,137,204,0.7)",
+        },
+      },
+      firstSymbolId
+    );
+    map.addLayer(
+      {
+        id: "chi-comm-lines",
+        type: "line",
+        source: "chi_comm",
+        "source-layer": "chi_comm",
+        layout: {
+          visibility: "none",
+        },
+        paint: {
+          "line-color": "rgba(106,137,204,0.7)",
+        },
+      },
+      firstSymbolId
+    );
   }
-  // upper layers
-  for (let upper in UPPER_KEYS) {
-    if (states[i] !== "dc") {
-      newSourceLayer(upper, UPPER_KEYS[upper]);
-    }
+  // leg2 : congressional district
+  // leg3 : state senate district
+  // leg4 : state house district
+  // adm2 : counties
+  // loc4 : neighborhoods
+  // pos4 : 5-digit postcode area
+  // sta5 : block groups
+  for (var key in BOUNDARIES_LAYERS) {
+    newBoundariesLayer(key, firstSymbolId);
   }
-  // lower layers
-  for (let lower in LOWER_KEYS) {
-    if (states[i] !== "dc") {
-      newSourceLayer(lower, LOWER_KEYS[lower]);
-    }
-  }
-  for (let i = 0; i < states.length; i++) {
-    newCensusLayer(states[i]);
-    if (states[i] !== "dc") {
-      newUpperLegislatureLayer(states[i]);
-      newLowerLegislatureLayer(states[i]);
-    }
-  }
-  map.addSource("counties", {
-    type: "vector",
-    url: "mapbox://mapbox.hist-pres-election-county",
-  });
-  map.addLayer({
-    id: "counties",
-    type: "line",
-    source: "counties",
-    "source-layer": "historical_pres_elections_county",
-    layout: {
-      visibility: "none",
-    },
-    paint: {
-      "line-color": "rgba(106,137,204,0.7)",
-      "line-width": 2,
-    },
-  });
 
   var outputstr = a.replace(/'/g, '"');
   a = JSON.parse(outputstr);
@@ -290,19 +266,18 @@ map.on("load", function () {
 });
 
 //create a button that toggles layers based on their IDs
-var toggleableLayerIds = [
-  "Census Blocks",
-  "State Legislature - House/Assembly",
-  "State Legislature - Senate",
-  "counties",
-];
+var toggleableLayerIds = JSON.parse(JSON.stringify(BOUNDARIES_LAYERS));
+// add selector for chicago wards + community areas if illinois
+if (state === "il") {
+  toggleableLayerIds["chi-ward"] = "Chicago Wards";
+  toggleableLayerIds["chi-comm"] = "Chicago Community Areas";
+}
 
-for (var i = 0; i < toggleableLayerIds.length; i++) {
-  var id = toggleableLayerIds[i];
+for (var id in toggleableLayerIds){
 
   var link = document.createElement("input");
 
-  link.value = id.replace(/\s+/g, "-").toLowerCase();
+  link.value = id;
   link.id = id;
   link.type = "checkbox";
   link.className = "switch_1";
@@ -310,39 +285,28 @@ for (var i = 0; i < toggleableLayerIds.length; i++) {
 
   link.onchange = function (e) {
     var txt = this.id;
-    var clickedLayers = [];
-    if (txt === "counties") {
-      clickedLayers.push(txt);
-    } else {
-      for (let i = 0; i < states.length; i++) {
-        if (states[i] !== "dc" || txt === "Census Blocks") {
-          clickedLayers.push(states[i].toUpperCase() + " " + txt);
-        }
-      }
-    }
-    // var clickedLayers = ["NJ " + txt, "VA " + txt, "PA " + txt, "MI " + txt];
+    // var clickedLayers = [];
+    // clickedLayers.push(txt + "-lines");
     e.preventDefault();
     e.stopPropagation();
 
-    for (var j = 0; j < clickedLayers.length; j++) {
-      var visibility = map.getLayoutProperty(clickedLayers[j], "visibility");
+    var visibility = map.getLayoutProperty(txt + "-lines", "visibility");
 
-      if (visibility === "visible") {
-        map.setLayoutProperty(clickedLayers[j], "visibility", "none");
-      } else {
-        map.setLayoutProperty(clickedLayers[j], "visibility", "visible");
-      }
+    if (visibility === "visible") {
+      map.setLayoutProperty(txt + "-lines", "visibility", "none");
+    } else {
+      map.setLayoutProperty(txt + "-lines", "visibility", "visible");
     }
   };
   // in order to create the buttons
   var div = document.createElement("div");
   div.className = "switch_box box_1";
   var label = document.createElement("label");
-  label.setAttribute("for", id.replace(/\s+/g, "-").toLowerCase());
-  label.textContent = id;
+  label.setAttribute("for", id);
+  label.textContent = toggleableLayerIds[id];
   var layers = document.getElementById("outline-menu");
   div.appendChild(link);
   div.appendChild(label);
   layers.appendChild(div);
   var newline = document.createElement("br");
-}
+};


### PR DESCRIPTION
**changes**
- switching from custom uploaded tilesets for blocks and legislature
- adding new data layers: neighborhoods, 5-digit postcode areas, congressional districts
- simplify code on map.js

**to test**
- go to any map page
- select and deselect data layers. ensure no js errors

**screenshots**
![image](https://user-images.githubusercontent.com/41943646/89401767-291c4080-d759-11ea-98b7-3703cc7c716f.png)

**next steps**
- implement boundaries in geo.js (need to spec out)
- data joins to enable ids & labels for data layers
  - hover for label
- custom tilesets still needed for school districts
- vary colors of data layers