### PR TITLE
entry page undo button

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -477,9 +477,6 @@ class UndoButton {
       } else {
         var undoFilter = filterStack.pop();
         var undoBbox = bboxStack.pop();
-        console.log("undo button pressed");
-        console.log(undoBbox);
-        console.log(bboxStack);
         map.setFilter(state + "-bg-highlighted", undoFilter);
         sessionStorage.setItem("bgFilter", JSON.stringify(undoFilter));
         sessionStorage.setItem("selectBbox", undoBbox);
@@ -512,8 +509,9 @@ class ClearMapButton {
     clear_button.innerHTML = "<i class='fas fa-trash-alt'></i> Clear Selection";
     this._map = map;
     clear_button.addEventListener("click", function (event) {
+      // check for empty map -- raise warning message if so
       var undoFilter = JSON.parse(sessionStorage.getItem("bgFilter"));
-      if (undoFilter === null) {
+      if (undoFilter === null || undoFilter.length < 4) {
         showWarningMessage("There is no selection to clear.")
         return;
       }
@@ -522,13 +520,9 @@ class ClearMapButton {
       );
       if (isConfirmed) {
         map.setFilter(state + "-bg-highlighted", ["in", "GEOID"]);
-        var undoFilter = JSON.parse(sessionStorage.getItem("bgFilter"));
         var undoBbox = sessionStorage.getItem("selectBbox");
         filterStack.push(undoFilter);
         bboxStack.push(undoBbox);
-        console.log("clear button pressed");
-        console.log(undoBbox);
-        console.log(bboxStack);
         sessionStorage.setItem("bgFilter", "[]");
         sessionStorage.setItem("selectBbox", "[]");
         sessionStorage.setItem("filterStack", JSON.stringify(filterStack));
@@ -915,7 +909,9 @@ map.on("style.load", function () {
         }
       });
       arraysEqual(filter, currentFilter) ? isChanged = false : isChanged = true;
-      // TODO - update selectBbox somehow? -- basically if isChanged, then get selectBbox - currentBbox and set selectBbox equal to that value
+      if (isChanged) {
+        selectBbox = turf.difference(selectBbox, currentBbox);
+      }
     } else {
       // check if previous selectBbox overlaps with current selectBbox
       if (selectBbox === null || selectBbox.length === 0) {
@@ -952,9 +948,6 @@ map.on("style.load", function () {
     if (isChanged) {
       filterStack.push(currentFilter);
       bboxStack.push(JSON.stringify(currentBbox));
-      console.log("clicked and selected");
-      console.log(selectBbox);
-      console.log(bboxStack);
       sessionStorage.setItem("filterStack", JSON.stringify(filterStack));
       sessionStorage.setItem("bboxStack", JSON.stringify(bboxStack));
       sessionStorage.setItem("bgFilter", JSON.stringify(filter));

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -480,7 +480,7 @@ class UndoButton {
         var undoFilter = filterStack.pop();
         var undoBbox = bboxStack.pop();
         map.setFilter(state + "-bg-highlighted", undoFilter);
-        sessionStorage.setItem("bgFilter", undoFilter);
+        sessionStorage.setItem("bgFilter", JSON.stringify(undoFilter));
         sessionStorage.setItem("selectBbox", undoBbox);
         sessionStorage.setItem("filterStack", JSON.stringify(filterStack));
         sessionStorage.setItem("bboxStack", JSON.stringify(bboxStack));

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -72,6 +72,15 @@ function sanitizePDF(x) {
 }
 
 map.on("load", function () {
+  var layers = map.getStyle().layers;
+  // Find the index of the first symbol layer in the map style
+  var firstSymbolId;
+  for (var i = 0; i < layers.length; i++) {
+    if (layers[i].type === "symbol" && layers[i] !== "road") {
+      firstSymbolId = layers[i].id;
+      break;
+    }
+  }
   // ward + community areas for IL
   if (state === "il") {
     newSourceLayer("chi_wards", CHI_WARD_KEY);
@@ -310,3 +319,9 @@ for (var id in toggleableLayerIds){
   layers.appendChild(div);
   var newline = document.createElement("br");
 };
+
+/*******************************************************************/
+// remove the last char in the string
+function removeLastChar(str) {
+  return str.substring(0, str.length - 1);
+}

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -540,7 +540,6 @@
                                                     <div id='menu'></div>
                                                     <div id='map' class='draw_polygon_map' onload="map.resize()">
                                                       <div id="warning-box-id" class="warning-box">
-                                                          <p class="mb-0"><i class="fa fa-exclamation-triangle"></i> Please ensure that your community does not contain any gaps. Your selected units must connect.</p>
                                                       </div>
                                                     </div>
                                                 </div>

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -539,7 +539,7 @@
                                                 <div class="map-box">
                                                     <div id='menu'></div>
                                                     <div id='map' class='draw_polygon_map' onload="map.resize()">
-                                                      <div id="warning-box-id" class="warning-box">
+                                                      <div id="warning-box-id" class="map-popup-box warning-box">
                                                       </div>
                                                     </div>
                                                 </div>

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -33,6 +33,7 @@
       <script type="text/javascript">
         let a = '{{ entries | escapejs}}';
         var mapbox_user_name = "{{mapbox_user_name}}";
+        var state = '';
       </script>
     </div>
     {% if entries is None %}


### PR DESCRIPTION
**changes**
- added an undo button on the entry page with the following behavior
  - after an action which draws, erases, or clears the map, allow to undo the previous action
  - if there is no action to undo, raise a warning
  - undo only applies for actions which impact the drawn community (ex. using the eraser but not deselecting any area doesn't apply)
- trying to clear an empty map raises a warning
- updates selection area upon using eraser tool or undo tool to fix edge cases for contiguity test + submission
- fix bugs on submission page

**to test**
- go to entry page
- search to begin drawing community
- try clearing an empty map. test that it raises a warning
- try undo-ing a non-action. test that it raises a warning
- test out drawing and subsequently undoing actions
- submit & confirm working submission action

**screenshots**
![image](https://user-images.githubusercontent.com/41943646/89721813-5f8de000-da25-11ea-9b6e-02d8ee41beaa.png)
