### PR TITLE
Org dash responsiveness

### DIFF
--- a/main/templates/main/dashboard/drives/index.html
+++ b/main/templates/main/dashboard/drives/index.html
@@ -46,21 +46,35 @@
         <div class="card-body">
           <h5>Getting Started</h5>
           <ul class="list-group my-3">
+
             <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div>
+              <div class="container pl-0 pr-0">
                 <h5><span class="badge badge-secondary"><i class="fas fa-share-alt"></i></span> Gather Submissions</h5>
-                <p>Gather submissions for this drive! Copy this link and share it with people you'd like to contribute to this drive: <a href="{% url 'main:drive_page' object.slug %}{{object.state}">representable.org{% url 'main:drive_page' object.slug %}</a></p>
+                <div class="row no-gutters">
+                  <div class="col-9">
+                    <p>Gather submissions for this drive! Copy this link and share it with people you'd like to contribute to this drive: <a href="{% url 'main:drive_page' object.slug %}{{object.state}}">representable.org{% url 'main:drive_page' object.slug %}</a></p>
+                  </div>
+                  <div class="col">
+                    <a class="btn btn-primary float-right" href="{% url 'main:drive_page' object.slug %}" role="button">View <i class="fa fa-arrow-circle-right"></i></a>
+                  </div>
+                </div>
               </div>
-              <a class="btn btn-primary" href="{% url 'main:drive_page' object.slug %}" role="button">View <i class="fa fa-arrow-circle-right"></i></a>
             </li>
 
 
 
             <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div>
+              <div class="container pl-0 pr-0">
                 <h5><span class="badge badge-secondary"><i class="fas fa-map-marker-alt"></i></span> View/Share Your Map</h5>
-                <p>Your drive's map is live at: <a href="{% url 'main:partner_map' object.organization.slug object.slug %}">representable.org{% url 'main:partner_map' object.organization.slug object.slug %}</a></p></div>
-                <a class="btn btn-primary" href="{% url 'main:partner_map' object.organization.slug object.slug %}"  role="button">View <i class="fa fa-arrow-circle-right"></i></a>
+                <div class="row no-gutters">
+                  <div class="col-9">
+                    <p>Your drive's map is live at: <a href="{% url 'main:partner_map' object.organization.slug object.slug %}">representable.org{% url 'main:partner_map' object.organization.slug object.slug %}</a></p>
+                  </div>
+                  <div class="col">
+                    <a class="btn btn-primary float-right" href="{% url 'main:partner_map' object.organization.slug object.slug %}"  role="button">View <i class="fa fa-arrow-circle-right"></i></a>
+                  </div>
+                </div>
+              </div>
             </li>
           </ul>
         </div>

--- a/main/templates/main/dashboard/partners/index.html
+++ b/main/templates/main/dashboard/partners/index.html
@@ -97,10 +97,17 @@
               <a class="btn btn-primary" href="{% url 'main:manage_org' object.slug  object.pk %}" role="button">Manage <i class="fa fa-arrow-circle-right"></i></a>
             </li>
             <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div>
+              <div class="container pl-0 pr-0">
                 <h5><span class="badge badge-secondary"><i class="fas fa-map-marker-alt"></i></span> View/Share Your Map</h5>
-                <p>Your organization's map is live at: <a href="{% url 'main:partner_map' object.slug %}">representable.org{% url 'main:partner_map' object.slug %}</a></p></div>
-                <a class="btn btn-primary" href="{% url 'main:partner_map' object.slug %}" role="button">View <i class="fa fa-arrow-circle-right"></i></a>
+                <div class="row no-gutters">
+                  <div class="col-9">
+                    <p>Your organization's map is live at: <a href="{% url 'main:partner_map' object.slug %}">representable.org{% url 'main:partner_map' object.slug %}</a></p>
+                  </div>
+                  <div class="col pb-3">
+                    <a class="btn btn-primary float-right" href="{% url 'main:partner_map' object.slug %}" role="button">View <i class="fa fa-arrow-circle-right"></i></a>
+                  </div>
+                </div>
+              </div>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
**Change:**
- buttons (on list items that include links) on org and drive home pages to be responsive

**To test:**
- navigate through the org dashboard on a mobile/developer tool that shows the mobile site
- navigate through the org dashboard on resized browser

Closes #157 