### PR TITLE
state entry pages for all states

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -926,9 +926,10 @@ map.on("style.load", function () {
 
   // Initialize Map for State Pages
   if (state_abbr !== "") {
+    state = state_abbr;
     showMap();
     map.flyTo({
-      center: statesLngLat[state_abbr],
+      center: statesLngLat[state_abbr.toUpperCase()],
       zoom: 6,
       essential: true, // this animation is considered essential with respect to prefers-reduced-motion
     });
@@ -936,7 +937,6 @@ map.on("style.load", function () {
     sessionStorage.setItem("bgFilter", "[]");
     sessionStorage.setItem("selectBbox", "[]");
 
-    state = state_abbr.toLowerCase();
     $("#shepherd-btn").removeClass("d-none");
     map.setLayoutProperty(state + "-census-lines", "visibility", "visible");
 

--- a/main/templates/main/drives/page.html
+++ b/main/templates/main/drives/page.html
@@ -24,8 +24,6 @@
       <p>{{object.description}}</p>
 
       {% if object.state == "MI" %}
-      <h6>Please help us improve our site! The Feedback Form appears at the bottom of each page.</h6>
-      <p>Thank you for helping to ensure that all people in Michigan will have an easy-to-use tool to draw their own community maps, which can be used to submit testimony to the Independent Citizens Redistricting Commission.</p>
       <h5>Redistricting in Michigan</h5>
       <p>Michigan has a new Independent Citizens Redistricting Commission voted into law in 2018 by the people of this State. Representable will help you tell the Commission about your community and draw a map of your community boundaries so the Commission can fairly consider your community when it draws new voting district lines.</p>
       <p>In the past, voting districts were drawn by politicians and their consultants behind closed doors with little or no public input. However, the shape of voting district maps can influence election outcomes, so it is important that new district maps be drawn in a transparent and impartial manner.</p>
@@ -48,7 +46,7 @@
       <p>It will provide a consistent format for Communities to use so the information will be easier for the Commission to consider in drawing the new voting district maps. </p>
       <p>Click "Draw My Community" below to share information about your Community and give your Community the voice it deserves!</p>
       {% endif %}
-        <a class="btn btn-primary btn-lg my-3 drive-new-entry" href="{% url 'main:entry' drive=object.slug %}{{object.state}}" role="button">Draw My Community</a>
+        <a class="btn btn-primary btn-lg my-3 drive-new-entry" href="{% url 'main:entry' drive=object.slug %}{{object.state|lower}}" role="button">Draw My Community</a>
       <!-- <a class="btn btn-outline-primary my-3" href="{% url 'main:partner_map' object.organization.slug object.slug %}" role="button">View map of communities</a> -->
     </div>
     </div>

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -35,8 +35,7 @@
     var organization_id = "{{organization_id}}";
     var drive_name = "{{drive_name}}";
     var organization_name = "{{organization_name}}";
-    var state_abbr = "{{state.abbr}}";
-    var state_name = "{{state.name}}";
+    var state_abbr = "{{state}}";
     mixpanel.track("Entry Page Loaded",
     {
      "drive_id": drive_id,

--- a/main/templates/main/state.html
+++ b/main/templates/main/state.html
@@ -85,7 +85,7 @@
           <h5 class="font-weight-light my-3">If you would like to create your own community independently of a partner organization, you can draw and export your community here.</h5>
         </div>
         <div class="col-sm-3">
-          <a class="btn ws-normal btn-outline-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}{{state_obj.abbr}}" role="button">Draw my community</a>
+          <a class="btn ws-normal btn-outline-primary btn-canvas my-3 font-weight-light" href="{% url 'main:entry' %}{{state_obj.abbr|lower}}" role="button">Draw my community</a>
         </div>
       </div>
     </div>

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -462,13 +462,7 @@ class EntryView(LoginRequiredMixin, View):
         return initial
 
     def get(self, request, abbr=None, *args, **kwargs):
-        state = None
-        if abbr:
-            statequery = State.objects.filter(abbr=abbr.upper())
-            try:
-                state = statequery[0]
-            except Exception:
-                state = None
+        state = abbr if abbr else None
 
         comm_form = self.community_form_class(
             initial=self.get_initial(), label_suffix=""


### PR DESCRIPTION
**changes**
- display map on /entry/{state_abbreviation} for all states when clicked on the map

**to test**
- go to map on landing page
- select a state without a state page, check map shows on entry page
- select a state with an entry page, check map shows
- go to a drive link :: /drive/{slug}, click on "Draw my community", check map shows

**other considerations**
- now, the only way to get to /entry/ is through the "Add community" button in the header -- we may want to redirect this button to go to the state selection screen on the landing page