### PR TITLE
Add checks, 404 redirect for invalid map_id param on submission urls

### DIFF
--- a/main/views/main.py
+++ b/main/views/main.py
@@ -472,9 +472,7 @@ class EntryView(LoginRequiredMixin, View):
         return initial
 
     def get(self, request, abbr=None, *args, **kwargs):
-        if abbr:
-            state = abbr
-        else:
+        if not abbr:
             return redirect("/#select")
 
         comm_form = self.community_form_class(
@@ -514,7 +512,7 @@ class EntryView(LoginRequiredMixin, View):
             "organization_id": organization_id,
             "drive_name": drive_name,
             "drive_id": drive_id,
-            "state": state,
+            "state": abbr,
         }
         return render(request, self.template_name, context)
 


### PR DESCRIPTION
Key Changes:
- Adds a 404 redirect for empty submission link without map_id param 
- Adds 404 redirect for invalid submission links (do not match re expression)
- Also redirects to 404 if map_id is queried and no submissions are found
- Resolves: https://github.com/Representable/securetracker/issues/7

Additional Context:
- Django sanitizes queries and protects from SQL injection attacks. However, re match and 404 fallbacks makes this failproof!

To test:
- Visit a map/drive, ensure that clicking on a community take you to a valid submission link
- Create a community then visit the link to the community on the thanks page