### PR TITLE
add founding team section to about page

### DIFF
--- a/main/templates/main/pages/about.html
+++ b/main/templates/main/pages/about.html
@@ -134,6 +134,16 @@
         <p class="p1 text-center"><strong>Mikala Parnell</strong> • Outreach Coordinator</p>
         <p class="p1 text-center"><strong>Edward Tian</strong> • Software Engineer</p>
       </div>
+      <h2 class="text-center font-weight-light mt-5">Our Founding Team</h2>
+      <hr class="line-break">
+      <div class="lead py-4">
+        <p class="small text-center">Representable began in February 2019 as a final project for the Princeton course COS333: Advanced Programming Techniques.</p>
+        <p class="p1 text-center"><strong>Somya Arora</strong> • Engineering, Full-Stack</p>
+        <p class="p1 text-center"><strong>Kyle Barnes</strong> • Engineering, Mapping </p>
+        <p class="p1 text-center"><strong>Preeti Iyer</strong> • Outreach, Content</p>
+        <p class="p1 text-center"><strong>Lauren Johnston</strong> • Engineering, Full-Stack</p>
+        <p class="p1 text-center"><strong>Theodor Marcu</strong> • Engineering, Product</p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
adding the names of the founders and a short blurb about how Rep started to the about page
![image](https://user-images.githubusercontent.com/41943646/94446491-b76bdc00-0176-11eb-91a7-f27aa644acea.png)
