### PR TITLE
Simplified mapping controls

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -558,8 +558,8 @@ color scheme. See readme.md*/
 }
 input[type=range]::-webkit-slider-thumb {
   border-radius: 50%;
-  width: 17.5px;
-  height: 17.5px;
+  width: 15px;
+  height: 15px;
 }
 
 /* css for the line on the progress bar */

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -556,6 +556,12 @@ color scheme. See readme.md*/
   /* font-family: Inter, system-ui, sans-serif; */
   /* font-size: 12px; */
 }
+input[type=range]::-webkit-slider-thumb {
+  border-radius: 50%;
+  margin-bottom: 6px;
+  width: 17.5px;
+  height: 17.5px;
+}
 
 /* css for the line on the progress bar */
 .bar-step {

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -558,7 +558,6 @@ color scheme. See readme.md*/
 }
 input[type=range]::-webkit-slider-thumb {
   border-radius: 50%;
-  margin-bottom: 6px;
   width: 17.5px;
   height: 17.5px;
 }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -359,7 +359,7 @@ class DropdownButton {
     dropdown_control.classList.add("active");
     dropdown_control.id = "map-dropdown-id";
     dropdown_control.style.display = "block";
-    dropdown_control.innerHTML = '<i class="fas fa-cog"></i><i class="fas fa-caret-down"></i>'
+    dropdown_control.innerHTML = '<i class="fas fa-cog"></i>' //&emsp;<i class="fas fa-caret-down"></i>
 
     this._map = map;
     this._container = document.createElement("div");
@@ -573,7 +573,9 @@ drawControls.appendChild(mapClearButton);
 
 // show more controls after clicking on dropdown
 var dropdownButton = document.getElementById("map-dropdown-id");
+var basicMode = true;
 dropdownButton.addEventListener("click", function (e) {
+  basicMode = false;
   var children = drawControls.children;
   for (let elem of children) {
     if (elem.id !== "map-dropdown-id") {
@@ -624,7 +626,7 @@ function newCensusLines(state) {
       visibility: "none",
     },
     paint: {
-      "line-color": "rgba(0,0,0,0.2)",
+      "line-color": "rgba(0,0,0,0.6)",
       "line-width": 1,
     },
   });
@@ -987,7 +989,8 @@ map.on("style.load", function () {
 
     var filter = [];
     var currentFilter = map.getFilter(state + "-bg-highlighted");
-    if (eraseMode) {
+    var isBasicErase = basicMode && currentFilter.includes(features[0]);
+    if (eraseMode || isBasicErase) {
       currentFilter.forEach(function (feature) {
         if (!features.includes(feature)) {
           filter.push(feature);

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -359,7 +359,7 @@ class DropdownButton {
     dropdown_control.classList.add("active");
     dropdown_control.id = "map-dropdown-id";
     dropdown_control.style.display = "block";
-    dropdown_control.innerHTML = '<i class="fas fa-cog"></i>' //&emsp;<i class="fas fa-caret-down"></i>
+    dropdown_control.innerHTML = '<i class="fas fa-cog"></i>'; //&emsp;<i class="fas fa-caret-down"></i>
 
     this._map = map;
     this._container = document.createElement("div");
@@ -575,6 +575,9 @@ drawControls.appendChild(mapClearButton);
 var dropdownButton = document.getElementById("map-dropdown-id");
 var basicMode = true;
 dropdownButton.addEventListener("click", function (e) {
+  mapClearButton.style.display === "none"
+    ? dropdownButton.innerHTML = '<i class="fas fa-cog"></i>&emsp;<i class="fas fa-caret-up"></i>'
+    : dropdownButton.innerHTML = '<i class="fas fa-cog">';
   basicMode = false;
   var children = drawControls.children;
   for (let elem of children) {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -575,10 +575,13 @@ drawControls.appendChild(mapClearButton);
 var dropdownButton = document.getElementById("map-dropdown-id");
 var basicMode = true;
 dropdownButton.addEventListener("click", function (e) {
-  mapClearButton.style.display === "none"
-    ? dropdownButton.innerHTML = '<i class="fas fa-cog"></i>&emsp;<i class="fas fa-caret-up"></i>'
-    : dropdownButton.innerHTML = '<i class="fas fa-cog">';
-  basicMode = false;
+  if (mapClearButton.style.display === "none") {
+    dropdownButton.innerHTML = '<i class="fas fa-cog"></i>&emsp;<i class="fas fa-caret-up"></i>';
+    basicMode = false;
+  } else {
+    dropdownButton.innerHTML = '<i class="fas fa-cog">';
+    basicMode = true;
+  }
   var children = drawControls.children;
   for (let elem of children) {
     if (elem.id !== "map-dropdown-id") {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -363,7 +363,7 @@ class SelectRadiusButton {
     radius_control.id = "map-radius-control-id";
     radius_control.style.display = "block";
     radius_control.innerHTML =
-      '<form><input type="range" min="1" max="50" value="25" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Size: <span id="radius-value">25</span></p></form>';
+      '<form><input type="range" min="1" max="50" value="25" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Tool Size</p></form>';
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group draw-group";
@@ -381,11 +381,11 @@ map.addControl(new SelectRadiusButton(), "top-right");
 var drawControls = document.getElementById("draw-group-container");
 
 var slider = document.getElementById("radius-control");
-var rangeVal = document.getElementById("radius-value");
+var style = document.querySelector('[data="slider-data"]');
 slider.oninput = function () {
   var size = this.value;
   drawRadius = parseInt(size);
-  rangeVal.innerHTML = size;
+  style.innerHTML = "input[type=range]::-webkit-slider-thumb { width: " + (size / 7 + 14)  + "px !important; height: " + (size / 7 + 14) + "px !important; }";
 };
 
 var eraseMode = false;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -999,9 +999,7 @@ map.on("style.load", function () {
     // todo: bug where you can select non-contiguous areas on basicMode
     if ((eraseMode && !basicMode) || isBasicErase) {
       currentFilter.forEach(function (feature) {
-        if (!features.includes(feature)) {
-          filter.push(feature);
-        }
+        if (!features.includes(feature)) filter.push(feature);
       });
       arraysEqual(filter, currentFilter)
         ? (isChanged = false)
@@ -1019,7 +1017,7 @@ map.on("style.load", function () {
         selectBbox = currentBbox;
         hideWarningMessage();
       } else {
-        if (turf.booleanDisjoint(currentBbox, selectBbox) && !isEmptyFilter(filter)) {
+        if (turf.booleanDisjoint(currentBbox, selectBbox) && !isEmptyFilter(currentFilter)) {
           showWarningMessage(
             "Please ensure that your community does not contain any gaps. Your selected units must connect."
           );

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -385,7 +385,7 @@ var style = document.querySelector('[data="slider-data"]');
 slider.oninput = function () {
   var size = this.value;
   drawRadius = parseInt(size);
-  style.innerHTML = "input[type=range]::-webkit-slider-thumb { width: " + (size / 7 + 14)  + "px !important; height: " + (size / 7 + 14) + "px !important; }";
+  style.innerHTML = "input[type=range]::-webkit-slider-thumb { width: " + (size / 7 + 14)  + "px !important; height: " + (size / 7 + 14) + "px !important; margin-top: "+ (-3 - size / 16.67) + "px !important; }";
 };
 
 var eraseMode = false;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -52,9 +52,6 @@ function closePopup() {
 
 /******************************************************************************/
 
-// Formset field object saves a deep copy of the original formset field object.
-// (If user deletes all fields, he can add one more according to this one).
-var formsetFieldObject;
 var state;
 $(document).ready(function () {
   // load tooltips (bootstrap)
@@ -352,6 +349,34 @@ var geocoder = new MapboxGeocoder({
 document.getElementById("geocoder").appendChild(geocoder.onAdd(map));
 
 /* Creating custom draw buttons */
+class DropdownButton {
+  onAdd(map) {
+    var dropdown_control = document.createElement("button");
+    dropdown_control.href = "#";
+    dropdown_control.type = "button";
+    dropdown_control.backgroundImg = "";
+
+    dropdown_control.classList.add("active");
+    dropdown_control.id = "map-dropdown-id";
+    dropdown_control.style.display = "block";
+    dropdown_control.innerHTML = '<i class="fas fa-cog"></i><i class="fas fa-caret-down"></i>'
+
+    this._map = map;
+    this._container = document.createElement("div");
+    this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group draw-group";
+    this._container.id = "draw-group-container";
+    this._container.appendChild(dropdown_control);
+    return this._container;
+  }
+
+  onRemove() {
+    this._container.parentNode.removeChild(this._container);
+    this._map = undefined;
+  }
+}
+map.addControl(new DropdownButton(), "top-right");
+var drawControls = document.getElementById("draw-group-container");
+
 class SelectRadiusButton {
   onAdd(map) {
     var radius_control = document.createElement("button");
@@ -361,13 +386,12 @@ class SelectRadiusButton {
 
     radius_control.classList.add("active");
     radius_control.id = "map-radius-control-id";
-    radius_control.style.display = "block";
+    radius_control.style.display = "none";
     radius_control.innerHTML =
-      '<form><input type="range" min="1" max="50" value="25" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Tool Size</p></form>';
+      '<form><input type="range" min="1" max="50" value="1" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Tool Size</p></form>';
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group draw-group";
-    this._container.id = "draw-group-container";
     this._container.appendChild(radius_control);
     return this._container;
   }
@@ -377,8 +401,10 @@ class SelectRadiusButton {
     this._map = undefined;
   }
 }
+
 map.addControl(new SelectRadiusButton(), "top-right");
-var drawControls = document.getElementById("draw-group-container");
+var radiusSelect = document.getElementById("map-radius-control-id");
+drawControls.append(radiusSelect);
 
 var slider = document.getElementById("radius-control");
 var style = document.querySelector('[data="slider-data"]');
@@ -399,7 +425,7 @@ class DrawButton {
 
     draw_button.classList.add("active");
     draw_button.id = "map-draw-button-id";
-    draw_button.style.display = "block";
+    draw_button.style.display = "none";
     draw_button.innerHTML = "<i class='fas fa-pencil-alt'></i> Draw";
     this._map = map;
     return draw_button;
@@ -423,7 +449,7 @@ class EraserButton {
 
     eraser_button.classList.add("active");
     eraser_button.id = "map-eraser-button-id";
-    eraser_button.style.display = "block";
+    eraser_button.style.display = "none";
     eraser_button.innerHTML = "<i class='fas fa-eraser'></i> Eraser";
     this._map = map;
     return eraser_button;
@@ -468,7 +494,7 @@ class UndoButton {
 
     undo_button.classList.add("active");
     undo_button.id = "map-undo-button-id";
-    undo_button.style.display = "block";
+    undo_button.style.display = "none";
     undo_button.innerHTML = "<i class='fas fa-undo-alt'></i> Undo";
     this._map = map;
     undo_button.addEventListener("click", function (event) {
@@ -509,7 +535,7 @@ class ClearMapButton {
 
     clear_button.classList.add("active");
     clear_button.id = "map-clear-button-id";
-    clear_button.style.display = "block";
+    clear_button.style.display = "none";
     clear_button.innerHTML = "<i class='fas fa-trash-alt'></i> Clear Selection";
     this._map = map;
     clear_button.addEventListener("click", function (event) {
@@ -544,6 +570,19 @@ class ClearMapButton {
 map.addControl(new ClearMapButton(), "top-right");
 var mapClearButton = document.getElementById("map-clear-button-id");
 drawControls.appendChild(mapClearButton);
+
+// show more controls after clicking on dropdown
+var dropdownButton = document.getElementById("map-dropdown-id");
+dropdownButton.addEventListener("click", function (e) {
+  var children = drawControls.children;
+  for (let elem of children) {
+    if (elem.id !== "map-dropdown-id") {
+      elem.style.display === "block" ? elem.style.display = "none" : elem.style.display = "block";
+    }
+  }
+});
+
+/****************************************************************************/
 
 function showWarningMessage(warning) {
   var warning_box = document.getElementById("warning-box-id");
@@ -862,7 +901,7 @@ myTour.addStep({
 
 /******************************************************************************/
 // the drawing radius for select tool
-var drawRadius = 25;
+var drawRadius = 0;
 var isStateChanged = false;
 /* After the map style has loaded on the page, add a source layer and default
 styling for a single point. */

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -581,6 +581,7 @@ dropdownButton.addEventListener("click", function (e) {
   } else {
     dropdownButton.innerHTML = '<i class="fas fa-cog">';
     basicMode = true;
+    drawRadius = 0;
   }
   var children = drawControls.children;
   for (let elem of children) {
@@ -1018,7 +1019,7 @@ map.on("style.load", function () {
         selectBbox = currentBbox;
         hideWarningMessage();
       } else {
-        if (turf.booleanDisjoint(currentBbox, selectBbox)) {
+        if (turf.booleanDisjoint(currentBbox, selectBbox) && !isEmptyFilter(filter)) {
           showWarningMessage(
             "Please ensure that your community does not contain any gaps. Your selected units must connect."
           );

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -388,7 +388,7 @@ class SelectRadiusButton {
     radius_control.id = "map-radius-control-id";
     radius_control.style.display = "none";
     radius_control.innerHTML =
-      '<form><input type="range" min="1" max="50" value="1" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Tool Size</p></form>';
+      '<form><input type="range" min="0" max="50" value="0" class="custom-range" id="radius-control"><p style="margin: 0;">Selection Tool Size</p></form>';
     this._map = map;
     this._container = document.createElement("div");
     this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group draw-group";
@@ -576,12 +576,11 @@ var dropdownButton = document.getElementById("map-dropdown-id");
 var basicMode = true;
 dropdownButton.addEventListener("click", function (e) {
   if (mapClearButton.style.display === "none") {
-    dropdownButton.innerHTML = '<i class="fas fa-cog"></i>&emsp;<i class="fas fa-caret-up"></i>';
+    dropdownButton.innerHTML = '<i class="fas fa-cog"></i> Settings <i class="fas fa-caret-up"></i>';
     basicMode = false;
   } else {
     dropdownButton.innerHTML = '<i class="fas fa-cog">';
-    basicMode = true;
-    drawRadius = 0;
+    if (drawRadius === 0) basicMode = true;
   }
   var children = drawControls.children;
   for (let elem of children) {
@@ -997,7 +996,8 @@ map.on("style.load", function () {
     var filter = [];
     var currentFilter = map.getFilter(state + "-bg-highlighted");
     var isBasicErase = basicMode && currentFilter.includes(features[0]);
-    if (eraseMode || isBasicErase) {
+    // todo: bug where you can select non-contiguous areas on basicMode
+    if ((eraseMode && !basicMode) || isBasicErase) {
       currentFilter.forEach(function (feature) {
         if (!features.includes(feature)) {
           filter.push(feature);

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -45,6 +45,7 @@
     }
     );
 </script>
+<style data="slider-data" type="text/css"></style>
 {% endblock %}
 
 {% block content %}

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -478,7 +478,7 @@
                                             <div class="map-bounding-box my-2 collapse">
                                                 <p>{% blocktrans %} Draw your community by selecting <a href="https://www.census.gov/programs-surveys/geography/about/glossary.html#par_textimage_4" target="_blank" data-toggle="tooltip" title="The units you are selecting to draw your community are census block groups. Map drawers use these units when creating districts.">units</a> on the map.
                                                    Make sure that all your community is contained within the highlighted units, and that your drawn community does not contain gaps.
-                                                   This will help the Redistricting Commission draw fairer districts using your entry. {% endblocktrans %}
+                                                   {% endblocktrans %}
                                                 </p>
                                                 <div class="map-box">
                                                     <div id='menu'></div>

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -85,7 +85,7 @@
       </p>
     </div>
     <!-- How To -->
-    <div class="row my-3">
+    <div class="row my-3 d-none d-sm-flex">
       <div class="col-sm my-3 shadow-sm mx-3">
         <div class="card border-0">
           <img class="card-img-top img-fluid small-icon m-2 h-25 w-50 mx-auto" src="{% static 'img/citizens.svg' %}"></img>
@@ -125,10 +125,10 @@
           <img class="card-img-top img-fluid small-icon m-2 h-25 w-50 mx-auto" src="{% static 'img/redistricter.svg' %}"></img>
           <div class="card-body text-center flex-column align-items-center">
             <h5 class="card-title">
-              {% trans "For redistricters" %}
+              {% trans "For mapmakers" %}
             </h5>
             <p class="card-text">
-              {% trans "Use our data to protect communities during the map drawing process." %}
+              {% trans "Use Representable data to protect communities during the map drawing process." %}
             </p>
             <div class="text-center">
               <a class="btn btn-outline-secondary mx-2 my-1 disabled" href="#" role="button">{% trans "Coming soon!" %}</a>


### PR DESCRIPTION
**changes**
- changed initial mapping form to a basic mode wherein users can select + deselect individual census block groups, one at a time. Click to select. Click to deselect.
- added a dropdown settings button, which when pressed allows users to interact with the same mapping controls as before (selection size, eraser, etc)
- when closing the dropdown, keeps the same selection size/eraser/draw options, with the exception of the case where the selection size is 0, or minimum

**to test**
- go to entry page
- mess around with drawing a community
- check contiguity test (can you draw communities of geographically discrete block groups?)
- check that mapping behaves as expected when switching between the settings dropdown

**note**
- plan is to merge this into staging so that both sites can be used for user testing. Making this PR to make it open for review before/during said testing