### PR TITLE
Login, Zoom Buttons, and Drive Creation issues fixes

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -178,6 +178,12 @@ class AllowlistForm(ModelForm):
 
 
 class DriveForm(ModelForm):
+    def __init__(self, org_states, *args, **kwargs):
+        super(DriveForm, self).__init__(*args, **kwargs)
+        choices = [state for state in STATES if state[0] in org_states]
+        self.fields["state"].widget = forms.Select(
+                choices=choices, attrs={"class": "form-control"}
+        )
     class Meta:
         model = Drive
         fields = ["name", "description", "state"]
@@ -193,9 +199,6 @@ class DriveForm(ModelForm):
                     "placeholder": "Short Description",
                     "class": "form-control",
                 }
-            ),
-            "state": forms.Select(
-                choices=STATES, attrs={"class": "form-control"}
             ),
         }
 

--- a/main/static/main/js/dash_review.js
+++ b/main/static/main/js/dash_review.js
@@ -44,7 +44,10 @@ map.addControl(
   })
 );
 
-map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+// Only add zoom buttons to medium and large screen devices (non-mobile)
+if (!window.matchMedia("only screen and (max-width: 760px)").matches) {
+  map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+}
 
 // add a new source layer
 function newSourceLayer(name, mbCode) {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -562,8 +562,10 @@ function hideWarningMessage() {
   warning_box.style.display = "none";
 }
 
-// Add nav control buttons.
-map.addControl(new mapboxgl.NavigationControl());
+// Only add zoom buttons to medium and large screen devices (non-mobile)
+if (!window.matchMedia("only screen and (max-width: 760px)").matches) {
+  map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+}
 
 var user_polygon_id = undefined;
 

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -48,7 +48,10 @@ map.addControl(
   })
 );
 
-map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+// Add zoom control for non-mobile devices
+if (!window.matchMedia("only screen and (max-width: 760px)").matches) {
+  map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+}
 
 // add a new source layer
 function newSourceLayer(name, mbCode) {

--- a/main/static/main/js/review.js
+++ b/main/static/main/js/review.js
@@ -44,7 +44,10 @@ map.addControl(
   })
 );
 
-map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+// Only add zoom buttons to medium and large screen devices (non-mobile)
+if (!window.matchMedia("only screen and (max-width: 760px)").matches) {
+  map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+}
 
 // add a new source layer
 function newSourceLayer(name, mbCode) {

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -30,7 +30,10 @@ map.addControl(
   })
 );
 
-map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+// Only add zoom buttons to medium and large screen devices (non-mobile)
+if (!window.matchMedia("only screen and (max-width: 760px)").matches) {
+  map.addControl(new mapboxgl.NavigationControl()); // plus minus top right corner
+}
 
 // add a new source layer
 function newSourceLayer(name, mbCode) {

--- a/main/templates/account/login.html
+++ b/main/templates/account/login.html
@@ -14,12 +14,16 @@
         <div class="card card-signin my-5">
             <div class="card-body">
                 <h4 class="card-title text-center">Welcome back! Sign in below.</h4>
-                <form id="log-in-form" class="form-signin login" method="POST" action="{% url 'account_login' %}">{% csrf_token %}
+                {% if login_error %}
+                    <div class="alert alert-danger" role="alert">
+                        {{login_error}}
+                    </div>
+                {% endif %}
+                <form id="log-in-form" class="form-signin login" method="POST" action="{% url 'account_login' %}">
                     {% csrf_token %}
                     <div class="form-group">
                         {% for field in form %}
                         <div class="field-wrap">
-                            {{ field.errors }}
                             {{ field|append_attr:"class:form-control my-2" }}
                             {% if field.help_text %}
                             <p class="help">{{ field.help_text|safe }}</p>

--- a/main/urls.py
+++ b/main/urls.py
@@ -24,6 +24,7 @@ from representable.settings.base import MAPBOX_KEY
 
 app_name = "main"
 urlpatterns = [
+    path("accounts/login/", views.main.RepresentableLoginView.as_view(), name="account_login"),
     path("", views.main.Index.as_view(), name="index"),
     path("map/", views.main.Map.as_view(), name="map"),
     path(

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -27,6 +27,7 @@ from django.views.generic import (
     DetailView,
     DeleteView,
 )
+from django import forms
 from django.views import View
 from django.core.mail import send_mail
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
@@ -499,6 +500,12 @@ class CreateDrive(LoginRequiredMixin, OrgAdminRequiredMixin, CreateView):
         )
 
         return super().form_valid(form)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        org = Organization.objects.get(pk=self.kwargs["pk"])
+        kwargs['org_states'] = org.states
+        return kwargs
 
 
 class UpdateDrive(LoginRequiredMixin, OrgAdminRequiredMixin, UpdateView):

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -41,6 +41,7 @@ from allauth.account.models import (
 )
 from allauth.account import adapter
 from allauth.account.app_settings import ADAPTER
+from allauth.account.views import LoginView
 from django.forms import formset_factory
 from ..forms import (
     CommunityForm,
@@ -115,6 +116,17 @@ class SignupRequiredMixin(AccessMixin):
 """
 Documentation: https://docs.djangoproject.com/en/2.1/topics/class-based-views/
 """
+
+class RepresentableLoginView(LoginView):
+    request = None
+    def dispatch(self, request, *args, **kwargs):
+        self.request = request
+        return super().dispatch(request, *args, **kwargs)
+    
+    def form_invalid(self, form):
+        context = self.get_context_data()
+        context['login_error'] = form.error_messages['email_password_mismatch']
+        return render(self.request, super().template_name, context)
 
 
 class Index(TemplateView):

--- a/representable/templates/base.html
+++ b/representable/templates/base.html
@@ -55,7 +55,7 @@
         var is_auth = false;
         {% endif %}
 
-      </script>
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
**changes**
- Display red bootstrap alert when a user enters a mismatched password
- Removes the zoom buttons on all of the maps when the device width is 760px or less
- Changes the state selection dropdown on the drive collection page, to only show the states that the organization is in.

**Issues Addressed**
- https://github.com/Representable/representable/issues/448#issue-726603352
- https://github.com/Representable/representable/issues/433#issue-718249746
- https://github.com/Representable/representable/issues/428#issue-718241574

**To test**
- On the login page type in a username and password that is incorrect. Should see red alert above the text boxes
- Go to a mobile phone device (< 760px) on the developer tool or use a mobile phone. Go to a map that originally had the zoom buttons. The zoom buttons should not be present.
- Create an organization and then click on the button to create a drive. In the states dropdown, you should only see the states that the organization is in.

<img width="483" alt="Login-error" src="https://user-images.githubusercontent.com/28410610/99594055-7db19780-29a7-11eb-8096-48de883175fb.png">