### PR TITLE
Login redesign fixed

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from allauth.account.forms import LoginForm, SignupForm
 from django import forms
 from django.forms import ModelForm
 from django_select2.forms import (
@@ -48,16 +49,24 @@ class AddressForm(ModelForm):
         fields = ["city", "state", "zipcode", "street"]
 
         widgets = {
-            "street": forms.TextInput(attrs={"placeholder": "Street", "maxlength": 500}),
-            "city": forms.TextInput(attrs={"placeholder": "City", "maxlength": 100}),
-            "state": forms.TextInput(attrs={"placeholder": "State", "maxlength": 100}),
-            "zipcode": forms.TextInput(attrs={"placeholder": "Zipcode", "maxlength": 12}),
+            "street": forms.TextInput(
+                attrs={"placeholder": "Street", "maxlength": 500}
+            ),
+            "city": forms.TextInput(
+                attrs={"placeholder": "City", "maxlength": 100}
+            ),
+            "state": forms.TextInput(
+                attrs={"placeholder": "State", "maxlength": 100}
+            ),
+            "zipcode": forms.TextInput(
+                attrs={"placeholder": "Zipcode", "maxlength": 12}
+            ),
         }
         labels = {
             "street": "Street: ",
             "city": "City: ",
             "state": "State: ",
-            "zipcode": "Zipcode: "
+            "zipcode": "Zipcode: ",
         }
 
 
@@ -87,14 +96,26 @@ class CommunityForm(ModelForm):
             "census_blocks_polygon": forms.HiddenInput(),
             "block_groups": forms.HiddenInput(),
             "entry_name": forms.TextInput(
-                attrs={"placeholder": "Community Name","maxlength": 100}
+                attrs={"placeholder": "Community Name", "maxlength": 100}
             ),
-            "entry_reason": forms.Textarea(attrs={"rows": 3, "maxlength": 500}),
-            "cultural_interests": forms.Textarea(attrs={"rows": 3, "maxlength": 500}),
-            "economic_interests": forms.Textarea(attrs={"rows": 3, "maxlength": 500}),
-            "comm_activities": forms.Textarea(attrs={"rows": 3, "maxlength": 500}),
-            "other_considerations": forms.Textarea(attrs={"rows": 3, "maxlength": 500}),
-            "user_name": forms.TextInput(attrs={"placeholder": "Full Name", "maxlength": 500}),
+            "entry_reason": forms.Textarea(
+                attrs={"rows": 3, "maxlength": 500}
+            ),
+            "cultural_interests": forms.Textarea(
+                attrs={"rows": 3, "maxlength": 500}
+            ),
+            "economic_interests": forms.Textarea(
+                attrs={"rows": 3, "maxlength": 500}
+            ),
+            "comm_activities": forms.Textarea(
+                attrs={"rows": 3, "maxlength": 500}
+            ),
+            "other_considerations": forms.Textarea(
+                attrs={"rows": 3, "maxlength": 500}
+            ),
+            "user_name": forms.TextInput(
+                attrs={"placeholder": "Full Name", "maxlength": 500}
+            ),
             "user_polygon": forms.HiddenInput(),
         }
         label = {
@@ -103,7 +124,7 @@ class CommunityForm(ModelForm):
             "cultural_interests": "Input your community's cultural or historical interests: ",
             "comm_activities": "Input your community's activities and services: ",
             "other_considerations": "Input your community's other interests and concerns: ",
-            "entry_name": "Input your community's name: "
+            "entry_name": "Input your community's name: ",
         }
 
     def clean(self):
@@ -182,8 +203,9 @@ class DriveForm(ModelForm):
         super(DriveForm, self).__init__(*args, **kwargs)
         choices = [state for state in STATES if state[0] in org_states]
         self.fields["state"].widget = forms.Select(
-                choices=choices, attrs={"class": "form-control"}
+            choices=choices, attrs={"class": "form-control"}
         )
+
     class Meta:
         model = Drive
         fields = ["name", "description", "state", "require_user_addresses"]
@@ -204,10 +226,8 @@ class DriveForm(ModelForm):
                 choices=STATES, attrs={"class": "form-control"}
             ),
             "require_user_addresses": forms.CheckboxInput(
-                attrs={
-                    "class": "form-control",
-                }
-            )
+                attrs={"class": "form-control"}
+            ),
         }
 
 
@@ -221,3 +241,19 @@ class MemberForm(ModelForm):
         fields = [
             "member",
         ]
+
+
+class RepresentableSignupForm(SignupForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for _, field in self.fields.items():
+            del field.widget.attrs["placeholder"]
+
+
+class RepresentableLoginForm(LoginForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for _, field in self.fields.items():
+            del field.widget.attrs["placeholder"]
+        self.fields["login"].label = "E-mail"
+        del self.fields["login"].widget.attrs["autofocus"]

--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -224,6 +224,12 @@ body {
   font-size: 2.9rem;
 }
 
+/* Class for what is gerrymandering section styling. */
+.what-is-gerrymandering {
+  background: -webkit-linear-gradient(-45deg, #2a94f4, #00c6a7);
+  color: white;
+}
+
 .tooltip-inner {
   background-color: gray !important;
 }
@@ -875,6 +881,144 @@ label {
 }
 
 /* LOGIN */
+/******************************************
+Signup and Login Page
+******************************************/
+#acc_already {
+  height: 50px;
+  color: rgba(101, 101, 101, 0.81);
+}
+
+.auth-form {
+  display: inline-block;
+  width: 70%;
+}
+
+.auth-form .btn {
+  font-size: 80%;
+  /* border-radius: 5rem; */
+  letter-spacing: 0.1rem;
+  font-weight: bold;
+  padding: 1rem;
+  transition: all 0.2s;
+}
+
+.auth-btn-wrap {
+  text-align: center;
+  padding-top: 20px;
+}
+
+.auth-btn {
+  width: 50%;
+}
+
+.auth-form-label {
+  text-align: left;
+  color: rgba(101, 101, 101, 0.61);
+}
+
+.auth-title {
+  color: #5b5b5b;
+}
+
+.auth-wrap {
+  margin: 25px 0px;
+  text-align: center;
+}
+
+.auth-field {
+  display: inline-block;
+  width: 100%;
+  height: 60px;
+  background-color: #cce9ff;
+  border: none;
+}
+
+.auth-divider-wrap {
+  position: relative;
+}
+
+.auth-divider {
+  position: absolute;
+  width: 0px;
+  height: 259.01px;
+  border-left: 5px solid rgba(0, 0, 0, 0.07);
+  transform: rotate(0.43deg);
+  left: 50%;
+  top: 30%;
+}
+
+.auth-link {
+  color: rgba(101, 101, 101, 0.81);
+  text-decoration: underline;
+}
+
+.auth-link:hover {
+  color: rgba(101, 101, 101, 1);
+}
+.login-field {
+  background-color: #d6f6f1;
+}
+
+.login-field:focus {
+  outline-color: #d6f6f1 !important;
+}
+
+#login-button {
+  background-color: #7adbcb;
+  border-color: #7adbcb;
+}
+
+.to-auth-link {
+  display: none;
+}
+
+.redirect-banner {
+  padding: 0px 30%;
+  text-align: center;
+}
+
+@media only screen and (min-width: 769px) {
+  #signup-form {
+    padding-top: 50px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .auth-divider-wrap {
+    text-align: center;
+    padding: 2.5rem 0rem;
+  }
+  .auth-divider {
+    position: initial;
+    display: inline-block;
+    width: 50%;
+    height: 0px;
+    border-bottom: 5px solid rgba(0, 0, 0, 0.07);
+    transform: rotate(0.43deg);
+  }
+
+  .auth-wrapper {
+    text-align: center;
+  }
+
+  .field-wrap {
+    text-align: center;
+  }
+
+  .to-auth-link {
+    display: inline-block;
+    padding-top: 30px;
+  }
+
+  .redirect-banner {
+    padding: 0px 15%;
+  }
+}
+
+.privacy-note {
+  color: rgba(101, 101, 101, 0.81);
+}
 
 :root {
   --input-padding-x: 1.5rem;
@@ -895,19 +1039,6 @@ label {
 
 .card-signin .card-body {
   padding: 2rem;
-}
-
-.form-signin {
-  width: 100%;
-}
-
-.form-signin .btn {
-  font-size: 80%;
-  /* border-radius: 5rem; */
-  letter-spacing: 0.1rem;
-  font-weight: bold;
-  padding: 1rem;
-  transition: all 0.2s;
 }
 
 .form-label-group {
@@ -969,10 +1100,6 @@ label {
   padding-bottom: calc(var(--input-padding-y) / 3);
   font-size: 12px;
   color: #777;
-}
-
-input.form-control[type="checkbox"] {
-  width: 15%;
 }
 
 .btn-google {

--- a/main/static/main/js/auth.js
+++ b/main/static/main/js/auth.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019- Representable Team (Theodor Marcu, Lauren Johnston, Somya Arora, Kyle Barnes, Preeti Iyer).
+ *
+ * This file is part of Representable
+ * (see http://representable.org).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+let jQuery = window.jQuery;
+
+var $root = $("html, body");
+
+jQuery(document).ready(function () {
+  authFocus();
+});
+
+$('a[href^="#"]').click(function () {
+  var link = $.attr(this, "href");
+  $root.animate(
+    {
+      scrollTop: $(link).offset().top,
+    },
+    500
+  );
+
+  if (link == "#login-form") {
+    $("#id_login").focus();
+  } else {
+    $("#id_email").focus();
+  }
+
+  return false;
+});
+
+let authFocus = function () {
+  if (window.location.href.indexOf("signup") > -1) {
+    $("#id_email").focus();
+  } else {
+    $("#id_login").focus();
+  }
+};

--- a/main/templates/account/login.html
+++ b/main/templates/account/login.html
@@ -1,51 +1,42 @@
-{% extends "account/base.html" %}
 <!--Modify the existing login template https://github.com/pennersr/django-allauth/blob/master/allauth/templates/account/login.html-->
 <!-- allows bootstrap in form-->
-
 {% load i18n %}
 {% load account socialaccount %}
 {% load widget_tweaks %}
 
-
-{% block content %}
-<div class="container>"
-<div class="row">
-    <div class="col-sm-9 col-md-7 col-lg-5 mx-auto">
-        <div class="card card-signin my-5">
-            <div class="card-body">
-                <h4 class="card-title text-center">Welcome back! Sign in below.</h4>
-                {% if login_error %}
-                    <div class="alert alert-danger" role="alert">
-                        {{login_error}}
-                    </div>
-                {% endif %}
-                <form id="log-in-form" class="form-signin login" method="POST" action="{% url 'account_login' %}">
-                    {% csrf_token %}
-                    <div class="form-group">
-                        {% for field in form %}
-                        <div class="field-wrap">
-                            {{ field|append_attr:"class:form-control my-2" }}
-                            {% if field.help_text %}
-                            <p class="help">{{ field.help_text|safe }}</p>
-                            {% endif %}
-                        </div>
-                        {% endfor %}
-                    </div>
-
-                    {% if redirect_field_value %}
-                    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-                    {% endif %}
-                    <button class="btn btn-lg btn-primary btn-block text-uppercase" type="submit">{% trans "Sign In" %}</button>
-                    <a class="btn btn-lg btn-primary-outline btn-block text-uppercase" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
-                </form>
-                <p class="card-text text-center my-3 align-text-bottom"><i class="fas fa-lock m-1 text-primary"></i>Accounts help us protect legitimate submissions.</p>
-                <hr>
-                <p class="card-text text-center my-3 align-text-bottom">Don't have an account yet?
-                    <a class="sign-up-started btn btn-outline-primary" href="/accounts/signup/?next={{ request.GET.next }}">Sign Up</a>
-                </p>
+<!-- Login component -->
+<div class="auth-wrap col-sm-9 col-md-7 col-lg-5 mx-auto">
+    <form id="login-form" class="login auth-form" method="POST" action="{% url 'account_login' %}">
+        {% if redirect_field_value %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+        {% endif %}
+        <div id="acc_already" class="text-left">{% trans "Already have an account?" %}</div>
+        <h4 class="auth-title">{% trans "Log In" %}</h4>
+        {% if login_error %}
+            <div class="alert alert-danger text-left" role="alert">
+                {{login_error}}
+            </div>
+        {% endif %}
+        {% csrf_token %}
+        <div class="form-group">
+            {% for field in login_form %}
+                {{ field.errors }}
+                <div class="auth-form-label">{{ field.label }}</div>
+                <div class="field-wrap">
+                    {{ field|append_attr:"class:form-control my-2 auth-field login-field" }}
                 </div>
+                {% if field.help_text %}
+                <p class="help">{{ field.help_text|safe }}</p>
+                {% endif %}
+            {% endfor %}
         </div>
-    </div>
+
+        <div class="text-left"><a class="auth-link" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a></div>
+        <div class="auth-btn-wrap">
+            <button id="login-button" class="btn btn-lg btn-primary text-uppercase auth-btn" type="submit">{% trans "log in" %}</button>
+        </div>
+
+        <a class="auth-link to-auth-link" href="#signup-form">{% trans "No Account? Sign up."%}</a>
+
+    </form>
 </div>
-</div>
-{% endblock %}

--- a/main/templates/account/signup.html
+++ b/main/templates/account/signup.html
@@ -1,44 +1,48 @@
 <!-- adaptation of official allauth code https://github.com/pennersr/django-allauth/blob/master/allauth/templates/account/signup.html-->
 <!-- allows bootstrap in form-->
-{% extends "account/base.html" %}
 {% load widget_tweaks %}
 
 {% load i18n %}
 
-{% block content %}
-<div class="container">
-<div class="row">
-  <div class="col-sm-9 col-md-7 col-lg-5 mx-auto">
-    <div class="card card-signin my-5">
-      <div class="card-body">
-        <h4 class="card-title text-center">Sign Up</h4>
-        <form id="sign-up-form" class="form-signin signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
-          {% csrf_token %}
-          <div class="form-group">
-            {% for field in form %}
-            <div class="field-wrap">
-              {{ field.errors }}
-              {{ field|append_attr:"class:form-control my-2" }}
-              {% if field.help_text %}
-              <p class="help">{{ field.help_text|safe }}</p>
-              {% endif %}
+<div class="auth-wrap col-sm-9 col-md-7 col-lg-5 mx-auto">
+    <form id="signup-form" class="signup auth-form" method="post" action="{% url 'account_signup' %}">
+        {% if redirect_field_value %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+        {% endif %}
+        <h4 class="auth-title">{% trans "Sign Up" %}</h4>
+        {% if signup_errors %}
+            <div class="alert alert-danger text-left">
+                {% for error in signup_errors.values%}
+                    <p>{{ error.0|escape }}</p>
+                {% endfor %}
             </div>
-            {% endfor %}
-          </div>
-          {% if redirect_field_value %}
-          <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-          {% endif %}
-          <button class="btn btn-lg btn-primary btn-block text-uppercase" type="submit">{% trans "Sign Up" %}</button>
-          </form>
-          <p class="card-text text-center my-3 align-text-bottom"><i class="fas fa-lock m-1 text-primary"></i>Making an account helps us protect legitimate submissions.</p>
-          <hr>
-          <p class="card-text text-center my-3 align-text-bottom">Already have an account?
-             <a class="log-in-started btn btn-outline-primary" href="/accounts/login/?next={{ request.GET.next }}">Log In</a>
-          </p>
+        {% endif %}
+        {% csrf_token %}
 
-      </div>
-    </div>
-  </div>
+        <div class="form-group">
+            {% for field in signup_form %}
+                <div class="auth-form-label">{{ field.label }}</div>
+                <div class="field-wrap">
+                    {{ field|append_attr:"class:form-control my-2 auth-field" }}
+                </div>
+                {% if field.help_text %}
+                    <p class="help">{{ field.help_text|safe }}</p>
+                {% endif %}
+            {% endfor %}
+        </div>
+
+        <div class="row equal">
+            <div class="col-lg-1 col-md-1 col-xs-12 text-center">
+                <i class="fas fa-lock m-1 text-primary"></i>
+            </div>
+            <div class="col-lg-10 col-md-9">
+                <p class="text-left align-text-bottom privacy-note">Making an account helps us protect legitimate submissions.</p>
+            </div>
+        </div>
+        <div class="auth-btn-wrap">
+            <button class="btn btn-lg btn-primary text-uppercase auth-btn" type="submit">{% trans "Sign Up" %}</button>
+        </div>
+
+        <a class="auth-link to-auth-link" href="#login-form">{% trans "Already have an account? Log in."%}</a>
+    </form>
 </div>
-</div>
-{% endblock %}

--- a/main/templates/account/signup_login.html
+++ b/main/templates/account/signup_login.html
@@ -1,0 +1,39 @@
+<!-- adaptation of official allauth code https://github.com/pennersr/django-allauth/blob/master/allauth/templates/account/signup.html-->
+<!-- allows bootstrap in form-->
+{% extends "account/base.html" %}
+{% load static %}
+{% load i18n %}
+{% load account socialaccount %}
+{% load widget_tweaks %}
+
+{% block content %}
+<div class="container">
+    {% if redirect_field_value %}
+    <div class="row">
+        <div class="col redirect-banner">
+            <div class="alert alert-info" role="alert">
+                {% trans "Let's have you sign up or log in before you start..." %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    <div class="row">
+        <!-- Login component -->
+        {% include './signup.html'%}
+
+
+        <div class="auth-divider-wrap col-lg-1">
+            <div class="auth-divider"></div>
+        </div>
+
+        <!-- Signup component -->
+        {% include './login.html'%}
+
+    </div>
+
+</div>
+{% endblock %}
+
+{% block script %}
+    <script type="text/javascript" src="{% static 'main/js/auth.js' %}"></script>
+{% endblock %} 

--- a/main/urls.py
+++ b/main/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
         views.main.RepresentableLoginView.as_view(),
         name="account_login",
     ),
+    path(
+        "accounts/signup/",
+        views.main.RepresentableSignupView.as_view(),
+        name="account_signup",
+    ),
     path("", views.main.Index.as_view(), name="index"),
     path("map/", views.main.Map.as_view(), name="map"),
     path(

--- a/representable/settings/base.py
+++ b/representable/settings/base.py
@@ -242,9 +242,10 @@ elif DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
     ] = "django.contrib.gis.db.backends.spatialite"
 
 # Can Log In With Either Email or Username
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+ACCOUNT_AUTHENTICATION_METHOD = "email"
 
 ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_USERNAME_REQUIRED = False
 DEFAULT_FROM_EMAIL = "no-reply@representable.org"
 
 ACCOUNT_EMAIL_VERIFICATION = "optional"


### PR DESCRIPTION
**changes**

-Authentication page now features the login form and signup form side by side with a new appearance
-Authentication redirection now features an alert at the top telling the user that login or signup is required.
-Authentication errors results in a red banner at the top of the form where the error occurs
-Username is now removed from the authentication process entirely: Closes #441 


**to test**

-Click login or signup button. If you click the login button, the focus should be on the email textbox of the login form. If you click the signup form should be on the email textbox of the signup form.
-On small tablet and mobile view, if you click on the "signup" and "login" links at the bottom of each form, the screen should be scrolled to and the focus should be on that respective form.
-To test the redirection: Make sure that you are logged out then click on a feature that requires authentication. If you put in the wrong information in either form then you should be redirected to the same page with the error displayed. When you put in the correct credentials you should be redirected to whatever page you were trying to access.

**screenshots**

**Note: The banner at the top of the redirection page should now read "Let's have you sign up or log in before you start..." not as pictured. Also, the signup form and login form positions are flipped from what is shown in pictures. However, the designs are the same.**



![image](https://user-images.githubusercontent.com/51216246/100799409-ff1b1800-33f2-11eb-9ac5-df41835d0f7c.png)


![image](https://user-images.githubusercontent.com/51216246/100799385-f591b000-33f2-11eb-9290-ebfa0b73f2af.png)

![image](https://user-images.githubusercontent.com/51216246/100799364-edd20b80-33f2-11eb-8b79-2fbdcdad147e.png)
