### PR TITLE
Changes the frontend design of the racaptcha box

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -732,6 +732,12 @@ input[type="range"]::-webkit-slider-thumb {
 
 /* Entry Form Management */
 
+.g-recaptcha {
+  display: inline-block;
+  padding: 40px 0px 10px 0px;
+  max-width: 80%;
+}
+
 .button-edit {
   display: none;
 }

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -555,6 +555,10 @@
                                         <hr>
                                         {% blocktrans %} Any saved communities are final. In order to edit a saved community you will need
                                         to create a new community and delete the old one. {% endblocktrans %}
+
+                                        <div class="row">
+                                            <div class="col text-center"><div class="g-recaptcha" data-sitekey="{{recaptcha_public}}"></div></div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -574,8 +578,6 @@
                     <div class="loader loader-small text-center"></div><span class="d-none d-sm-inline"> {% trans "Saving Community..." %}</span>
                     </button>
                 </div>
-                <p id="captcha" style="color:red"> </p>
-                <div class="g-recaptcha" data-sitekey="{{recaptcha_public}}"></div>
                     <div class='row row-equal-cols'>
                         <div class='col-lg text-center m-2'>
                             <div style="display: inline-block;">


### PR DESCRIPTION
**changes**
- Changes the position of the recaptcha box to be centered within the privacy card

**to test**
- Go to the entry form page of any state and scroll to the privacy section

**screenshots**
*Note: The red text should not be present on production*
<img width="1544" alt="recaptcha-frontend-fix" src="https://user-images.githubusercontent.com/28410610/100928993-d1d67480-349b-11eb-9599-294e261f014e.png">
