### PR TITLE
Revert get calls to AWS

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -299,6 +299,7 @@ class CommunityEntry(models.Model):
     other_considerations = models.TextField(
         max_length=500, blank=True, unique=False, default=""
     )
+    # make this foreign key relation
     state = models.CharField(
         max_length=10, blank=True, unique=False, default=""
     )

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -658,6 +658,7 @@ class Map(TemplateView):
         # all communities for display TODO: might need to limit this? or go by state
         org = Organization.objects.get(id=0)
         query = org.submissions.all().prefetch_related("drive")
+        # state map page --> drives in the state, entries without a drive but with a state
         drives = []
         # query = (
         #     CommunityEntry.objects.all()
@@ -871,7 +872,6 @@ class EntryView(LoginRequiredMixin, View):
                 ServerSideEncryption="AES256",
                 StorageClass="STANDARD_IA",
             )
-            entryForm.census_blocks_polygon = ""
 
             entryForm.save()
             comm_form.save_m2m()

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -267,7 +267,7 @@ class MultiExportView(TemplateView):
             if not entry.organization:
                 continue
             gj = make_geojson(request, entry)
-        all_gj.append(gj)
+            all_gj.append(gj)
 
         final = geojson.FeatureCollection(all_gj)
 

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -18,9 +18,7 @@ from django.views.generic import (
     DetailView,
 )
 
-import asyncio
 import boto3
-import aioboto3
 import botocore
 import pandas
 from django.contrib.gis import geos
@@ -30,7 +28,6 @@ from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 import json
 import os
 import geojson
-import time
 from django.shortcuts import get_object_or_404
 from geojson_rewind import rewind
 from django.core.serializers import serialize
@@ -64,7 +61,6 @@ class PartnerMap(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        actual_start = time.time()
 
         # the polygon coordinates
         entryPolyDict = dict()
@@ -88,7 +84,6 @@ class PartnerMap(TemplateView):
         # address information if admin/user drew the comms
         streets = {}
         cities = {}
-        start_time_aws = time.time()
         for obj in query:
             if not obj.census_blocks_polygon and obj.user_polygon:
                 s = "".join(obj.user_polygon.geojson)
@@ -148,113 +143,97 @@ class PartnerMap(TemplateView):
             context["drive_slug"] = self.kwargs["drive"]
         if self.request.user.is_authenticated:
             context["is_org_admin"] = self.request.user.is_org_admin(org.id)
-        print("--- %s seconds for AWS---" % (time.time() - start_time_aws))
-        print("--- %s seconds including query---" % (time.time() - actual_start))
         return context
 
 
-async def getcomms(query, client, is_admin, drive):
-    comms = []
-    entryPolyDict = dict()
-    streets = {}
-    cities = {}
-    tasks = []
-    async with aioboto3.client(
-            "s3",
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),) as client:
-        for obj in query:
-            tasks.append(insideloop(obj, client, is_admin, drive))
+# async def getcomms(query, client, is_admin, drive):
+#     comms = []
+#     entryPolyDict = dict()
+#     streets = {}
+#     cities = {}
+#     tasks = []
+#     async with aioboto3.client(
+#             "s3",
+#             aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+#             aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),) as client:
+#         for obj in query:
+#             tasks.append(insideloop(obj, client, is_admin, drive))
 
-        results = await asyncio.gather(*tasks)
-        # print(results)
-        for item in results:
-            # print(item)
-            comms.append(item[0])
-            entryPolyDict[item[0].entry_ID] = item[1]
-            if item[2] and item[3]:
-                streets[item[0].entry_ID] = item[2]
-                cities[item[0].entry_ID] = item[3]
+#         results = await asyncio.gather(*tasks)
+#         for item in results:
+#             comms.append(item[0])
+#             entryPolyDict[item[0].entry_ID] = item[1]
+#             if item[2] and item[3]:
+#                 streets[item[0].entry_ID] = item[2]
+#                 cities[item[0].entry_ID] = item[3]
 
-    # print(type(results))
-    # print(type(results[0]))
-    # print(results[0])
-    return entryPolyDict, comms, streets, cities
+#     return entryPolyDict, comms, streets, cities
 
-async def insideloop(obj, client, is_admin, drive):
-    try:
-        comm, coords = await getfroms3(
-            client, obj, drive, obj.state, is_admin
-        )
-    except Exception:
-        if not obj.census_blocks_polygon and obj.user_polygon:
-            s = "".join(obj.user_polygon.geojson)
-        elif obj.census_blocks_polygon:
-            s = "".join(obj.census_blocks_polygon.geojson)
-        else:
-            return None
-        if is_admin:
-            if not obj.user_name:
-                obj.user_name = obj.user.username
-        else:
-            if obj.user_name:
-                obj.user_name = ""
+# async def insideloop(obj, client, is_admin, drive):
+#     try:
+#         comm, coords = await getfroms3(
+#             client, obj, drive, obj.state, is_admin
+#         )
+#     except Exception:
+#         if not obj.census_blocks_polygon and obj.user_polygon:
+#             s = "".join(obj.user_polygon.geojson)
+#         elif obj.census_blocks_polygon:
+#             s = "".join(obj.census_blocks_polygon.geojson)
+#         else:
+#             return None
+#         if is_admin:
+#             if not obj.user_name:
+#                 obj.user_name = obj.user.username
+#         else:
+#             if obj.user_name:
+#                 obj.user_name = ""
 
-        # comms.append(obj)
-        struct = geojson.loads(s)
-        coords = struct.coordinates
-        # entryPolyDict[obj.entry_ID] = struct.coordinates
+#         struct = geojson.loads(s)
+#         coords = struct.coordinates
 
-    print("requests finished at time %s" % time.time())
-    street = None
-    city = None
-    if is_admin:
-        for a in Address.objects.filter(entry=obj):
-            # streets[obj.entry_ID] = a.street
-            # cities[obj.entry_ID] = (
-            #     a.city + ", " + a.state + " " + a.zipcode
-            # )
-            street = a.street
-            city = a.city + ", " + a.state + " " + a.zipcode
-    return obj, coords, street, city
+#     print("requests finished at time %s" % time.time())
+#     street = None
+#     city = None
+#     if is_admin:
+#         for a in Address.objects.filter(entry=obj):
+#             street = a.street
+#             city = a.city + ", " + a.state + " " + a.zipcode
+#     return obj, coords, street, city
 
 
-async def getfroms3(client, obj, drive, state, is_admin):
-    print("request made at time %s" % time.time())
-    if drive:
-        folder_name = drive.slug
-    elif not drive and obj.drive:
-        folder_name = obj.drive.slug
-    else:
-        folder_name = state
-    response = await client.get_object(
-        Bucket=os.environ.get("AWS_STORAGE_BUCKET_NAME"),
-        Key=str(folder_name) + "/" + obj.entry_ID + ".geojson",
-    )
-    # print(response)
-    strobj = await response["Body"].read()
-    strobject = strobj.decode("utf-8")
-    mapentry = geojson.loads(strobject)
-    comm = CommunityEntry(
-        entry_ID=obj.entry_ID,
-        comm_activities=mapentry["properties"]["comm_activities"],
-        entry_name=mapentry["properties"]["entry_name"],
-        economic_interests=mapentry["properties"]["economic_interests"],
-        other_considerations=mapentry["properties"]["other_considerations"],
-        cultural_interests=mapentry["properties"]["cultural_interests"],
-    )
-    comm.drive = Drive(name=mapentry["properties"]["drive"])
-    comm.organization = Organization(
-        name=mapentry["properties"]["organization"]
-    )
-    if is_admin:
-        if obj.user_name:
-            comm.user_name = obj.user_name
-        else:
-            obj.user.username
-    # comms.append(comm)
-    # entryPolyDict[obj.entry_ID] = mapentry["geometry"]["coordinates"]
-    return comm, mapentry["geometry"]["coordinates"]
+# async def getfroms3(client, obj, drive, state, is_admin):
+#     print("request made at time %s" % time.time())
+#     if drive:
+#         folder_name = drive.slug
+#     elif not drive and obj.drive:
+#         folder_name = obj.drive.slug
+#     else:
+#         folder_name = state
+#     response = await client.get_object(
+#         Bucket=os.environ.get("AWS_STORAGE_BUCKET_NAME"),
+#         Key=str(folder_name) + "/" + obj.entry_ID + ".geojson",
+#     )
+#     strobj = await response["Body"].read()
+#     strobject = strobj.decode("utf-8")
+#     mapentry = geojson.loads(strobject)
+#     comm = CommunityEntry(
+#         entry_ID=obj.entry_ID,
+#         comm_activities=mapentry["properties"]["comm_activities"],
+#         entry_name=mapentry["properties"]["entry_name"],
+#         economic_interests=mapentry["properties"]["economic_interests"],
+#         other_considerations=mapentry["properties"]["other_considerations"],
+#         cultural_interests=mapentry["properties"]["cultural_interests"],
+#     )
+#     comm.drive = Drive(name=mapentry["properties"]["drive"])
+#     comm.organization = Organization(
+#         name=mapentry["properties"]["organization"]
+#     )
+#     if is_admin:
+#         if obj.user_name:
+#             comm.user_name = obj.user_name
+#         else:
+#             obj.user.username
+#     return comm, mapentry["geometry"]["coordinates"]
 
 
 # ******************************************************************************#
@@ -283,11 +262,6 @@ class MultiExportView(TemplateView):
                 geojson.dumps({}), content_type="application/json"
             )
 
-        client = boto3.client(
-            "s3",
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-        )
         all_gj = []
         for entry in query:
             if not entry.organization:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-aioboto3==8.2.0
-aiobotocore==1.1.2
-aiohttp==3.7.3
-aioitertools==0.7.1
 arabic-reshaper==2.1.1
 astroid==2.3.3
 autopep8==1.4.4


### PR DESCRIPTION
Changes made:
* revert getting entries from aws for partner map/drive map/submission and review pages
* restored original geojson export functionality for submission/review/map pages

To test:
* create an entry in a drive
* view the map page for the drive
* view the partner map page for the org
* go to the review page and find ur entry
* export entries on the review page
* go to the submission page for the entry
* export the entry on the submission page
* go to the drive page and export entries
* go to org map page and export entries
