### PR TITLE
frontend forms only accept 1 state

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -183,13 +183,37 @@ class OrganizationForm(ModelForm):
                     "placeholder": "External link to your organization's website. Include 'http'."
                 }
             ),
-            "states": Select2MultipleWidget(
+            "states": forms.Select(
                 choices=STATES, attrs={"data-placeholder": "Select States"},
             ),
         }
 
+class EditOrganizationForm(ModelForm):
+    class Meta:
+        model = Organization
+        fields = ["name", "description", "ext_link"]
+        labels = {
+            "name": "Organization Name",
+            "ext_link": "Link to Organization Website",
+        }
+        widgets = {
+            "name": forms.TextInput(
+                attrs={"placeholder": "Name of Organization"}
+            ),
+            "description": forms.Textarea(
+                attrs={
+                    "placeholder": "Short Description",
+                    "rows": 4,
+                    "cols": 20,
+                }
+            ),
+            "ext_link": forms.TextInput(
+                attrs={
+                    "placeholder": "External link to your organization's website. Include 'http'."
+                }
+            ),
+        }
 
-#
 class AllowlistForm(ModelForm):
     class Meta:
         model = Organization

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -43,6 +43,7 @@ from ..forms import (
     OrganizationForm,
     AllowlistForm,
     MemberForm,
+    EditOrganizationForm,
 )
 from ..models import (
     Membership,
@@ -205,7 +206,7 @@ class EditOrg(LoginRequiredMixin, OrgAdminRequiredMixin, UpdateView):
     """
 
     template_name = "main/dashboard/partners/edit.html"
-    form_class = OrganizationForm
+    form_class = EditOrganizationForm
     model = Organization
 
 


### PR DESCRIPTION
When creating a new org, only a single state can be selected. Once an org is created, the state cannot be changed anymore.

Does not change the Organization Model to force only 1 state ... since old organizations might have multiple states already attached.

To test: try creating an organization and editing an organization

