### PR TITLE
modal shud vanish when geocoder searched

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -685,6 +685,10 @@ var modalGeocoder = new MapboxGeocoder({
 document.getElementById("geocoder").appendChild(geocoder.onAdd(map));
 document.getElementById("modal-geocoder").appendChild(modalGeocoder.onAdd(map));
 
+modalGeocoder.on('result', function () {
+  $('#entry-map-modal').modal('hide');
+})
+
 /* Creating custom draw buttons */
 class DropdownButton {
   onAdd(map) {


### PR DESCRIPTION
To test:
Go to survey page
At the map drawing step, note when you search something on the modal, the modal automatically disappears