### PR TITLE
Map contiguity check for erase

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -144,7 +144,7 @@ form:invalid {
   background: #DFDFDF;
   width: 50px;
   height: .25rem;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .progress-line-vert {
@@ -220,7 +220,7 @@ form:invalid {
 
 .map-popup-box {
   position: absolute;
-  top: 10px;
+  top: 63px;
   left: 10px;
   background-color: rgba(255, 255, 255, 0.9);
   padding: 10px;
@@ -232,6 +232,7 @@ form:invalid {
 }
 .warning-box {
   border: 1px solid red;
+  font-size: 1rem;
 }
 
 /*********************************************************************
@@ -837,6 +838,7 @@ Entry Mapping Page
 #map-comm-info {
   vertical-align: middle;
   margin: auto;
+  top: 10px !important;
 }
 
 #map-top-row {
@@ -871,6 +873,7 @@ Entry Mapping Page
 #map-help-menu {
   height: fit-content;
   max-height: 800px;
+  top: 10px !important;
 }
 
 .comm-info-text {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1008,7 +1008,7 @@ function showWarningMessage(warning) {
   warning_box.style.display = "block";
   setTimeout(function () {
     warning_box.style.display = "none";
-  }, 4000);
+  }, 10000);
 }
 
 function hideWarningMessage() {
@@ -1427,10 +1427,8 @@ map.on("style.load", function () {
           selectBbox = turf.difference(selectBbox, currentBbox);
           if (turf.getType(selectBbox) == "MultiPolygon") {
             showWarningMessage(
-              "Please ensure that your community does not contain any gaps. Your selected units must connect."
+              "WARNING: We have detected that your community may consist of separate parts. If you choose to submit this community, only the largest connected piece will be visible on Representable.org"
             );
-            selectBbox = currentBbox.slice();
-            filter = currentFilter.slice();
           }
         }
       }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -1429,13 +1429,13 @@ map.on("style.load", function () {
             showWarningMessage(
               "Please ensure that your community does not contain any gaps. Your selected units must connect."
             );
-            selectBbox = turf.union(selectBbox, currentBbox);
+            selectBbox = currentBbox.slice();
             filter = currentFilter.slice();
           }
         }
       }
     } else {
-      // this is select mode 
+      // this is select mode
       // check if previous selectBbox overlaps with current selectBbox
       if (selectBbox === null || selectBbox.length === 0) {
         isChanged = true;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -182,7 +182,7 @@ $('#map-comm-modal').on('shown.bs.modal hidden.bs.modal', function() {
   $("#mobile-map-comm-btn").toggleClass("opened")
 });
 
-/** 
+/**
  * "May not be needed": Lines tagged with this are meant to animate the load in between the progress bars on a mobile view. However
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
@@ -211,7 +211,7 @@ function animateStepForward(at, to, after) {
   }, 600);
 }
 
-/** 
+/**
  * "May not be needed": Lines tagged with this are meant to animate the load in between the progress bars on a mobile view. However
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
@@ -262,7 +262,7 @@ function startSurvey() {
 function surveyP1ToSurveyStart() {
   $("#survey-qs-p1").addClass("d-none");
   $("#entry-survey-start").removeClass("d-none");
-  $("#2to3").removeClass("h-50"); 
+  $("#2to3").removeClass("h-50");
 }
 
 function surveyP1ToP2() {
@@ -1410,6 +1410,7 @@ map.on("style.load", function () {
     // todo: bug where you can select non-contiguous areas on basicMode
     if ((eraseMode && !basicMode) || isBasicErase) {
       currentFilter.forEach(function (feature) {
+        // push current filter MINUS the selected area
         if (!features.includes(feature)) filter.push(feature);
       });
       arraysEqual(filter, currentFilter)
@@ -1419,10 +1420,22 @@ map.on("style.load", function () {
         if (isEmptyFilter(filter)) {
           sessionStorage.setItem("selectBbox", "[]");
         }
-        if (selectBbox === null) selectBbox = [];
-        else selectBbox = turf.difference(selectBbox, currentBbox);
+        if (selectBbox === null) {
+          selectBbox = [];
+        }
+        else {
+          selectBbox = turf.difference(selectBbox, currentBbox);
+          if (turf.getType(selectBbox) == "MultiPolygon") {
+            showWarningMessage(
+              "Please ensure that your community does not contain any gaps. Your selected units must connect."
+            );
+            selectBbox = turf.union(selectBbox, currentBbox);
+            filter = currentFilter.slice();
+          }
+        }
       }
     } else {
+      // this is select mode 
       // check if previous selectBbox overlaps with current selectBbox
       if (selectBbox === null || selectBbox.length === 0) {
         isChanged = true;

--- a/main/templates/main/dashboard/partners/review.html
+++ b/main/templates/main/dashboard/partners/review.html
@@ -92,22 +92,22 @@
                 <span class="font-weight-light comm-content">
                   <span class="more-content">
                     {% if c.cultural_interests %}
-                    <b><i class="fas fa-palette"></i> Cultural Interests</b><br>
+                    <b><i class="fas fa-palette"></i> Cultural or Historical Interests</b><br>
                     <span class="text-muted small">{{c.cultural_interests}}</span>
                     <br>
                     {% endif %}
                     {% if c.comm_activities %}
-                    <b><i class="fas fa-hiking"></i> Community Activities</b><br>
+                    <b><i class="fas fa-hiking"></i> Community Activities and Services</b><br>
                     <span class="text-muted small">{{c.comm_activities}}</span>
                     <br>
                     {% endif %}
                     {% if c.economic_interests %}
-                    <b><i class="fas fa-comments-dollar"></i> Economic Interests</b><br>
+                    <b><i class="fas fa-comments-dollar"></i> Economic or Environmental Interests</b><br>
                     <span class="text-muted small">{{c.economic_interests}}</span>
                     <br>
                     {% endif %}
                     {% if c.other_considerations %}
-                    <b><i class="fas fa-users"></i> Other Interests</b><br>
+                    <b><i class="fas fa-users"></i> Community Needs and Concerns</b><br>
                     <span class="text-muted small">{{c.other_considerations}}</span>
                     <br>
                     {% endif %}

--- a/main/templates/main/entry_map.html
+++ b/main/templates/main/entry_map.html
@@ -105,7 +105,7 @@
                 <p class="ml-4 comm-item-text"> Community Population: <span class="font-weight-normal comm-pop">0</span></p>
                 <div class="accordion ml-4 mr-4 mt-1 map-info-item" id="mobile-map-economic-interests-accordion">
                     <button class="btn btn-link text-left comm-item-text pl-2 no-underline-link" type="button" data-target="#mobile-map-economic-interests-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
-                        {% trans "Economic and Environmental Interests" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
+                        {% trans "Economic or Environmental Interests" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
                     </button>
                     <div id="mobile-map-economic-interests-resp" class="collapse pl-2 pb-1" aria-labelledby="mobile-map-economic-interests-accordion" data-parent="#mobile-map-economic-interests-accordion">
                         <p class="collapse-in map-survey-response">
@@ -135,7 +135,7 @@
                 </div>
                 <div class="accordion map-info-item ml-4 mr-4 mt-3 mb-5" id="mobile-map-other-interests-accordion">
                     <button class="btn btn-link text-left comm-item-text pl-2 no-underline-link" type="button" data-target="#mobile-map-other-interests-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
-                        {% trans "Other Interests and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
+                        {% trans "Community Needs and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
                     </button>
                     <div id="mobile-map-other-interests-resp" class="collapse pl-2 pb-1" aria-labelledby="mobile-map-other-interests-accordion" data-parent="#mobile-map-other-interests-accordion">
                         <p class="collapse-in map-survey-response">
@@ -231,7 +231,7 @@
                             <p class="ml-4 comm-item-text"> Community Population: <span class="font-weight-normal comm-pop">0</span></p>
                             <div class="dropdown-item accordion map-info-item ml-4 mr-4 mt-1" id="map-economic-interests-accordion">
                                 <button class="btn btn-link text-left comm-item-text pl-0 no-underline-link" type="button" data-target="#map-economic-interests-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
-                                    {% trans "Economic and Environmental Interests" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
+                                    {% trans "Economic or Environmental Interests" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
                                 </button>
                                 <div id="map-economic-interests-resp" class="collapse" aria-labelledby="comm_activities_accordion" data-parent="#map-economic-interests-resp">
                                     <p class="collapse-in map-survey-response">
@@ -261,7 +261,7 @@
                             </div>
                             <div class="dropdown-item accordion map-info-item ml-4 mr-4 mt-3 mb-3" id="map-other-interests-accordion">
                                 <button class="btn btn-link text-left comm-item-text pl-0 no-underline-link" type="button" data-target="#map-other-interests-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
-                                    {% trans "Other Interests and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
+                                    {% trans "Community Needs and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
                                 </button>
                                 <div id="map-other-interests-resp" class="collapse" aria-labelledby="map-other-interests-accordion" data-parent="#map-other-interests-accordion">
                                     <p class="collapse-in map-survey-response">

--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -87,22 +87,22 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                     <span class="font-weight-light comm-content">
                       <span class="more-content">
                         {% if c.cultural_interests %}
-                        <b><i class="fas fa-palette"></i> Cultural Interests</b><br>
+                        <b><i class="fas fa-palette"></i> Cultural or Historical Interests</b><br>
                         <span class="text-muted small">{{c.cultural_interests}}</span>
                         <br>
                         {% endif %}
                         {% if c.comm_activities %}
-                        <b><i class="fas fa-hiking"></i> Community Activities</b><br>
+                        <b><i class="fas fa-hiking"></i> Community Activities and Services</b><br>
                         <span class="text-muted small">{{c.comm_activities}}</span>
                         <br>
                         {% endif %}
                         {% if c.economic_interests %}
-                        <b><i class="fas fa-comments-dollar"></i> Economic Interests</b><br>
+                        <b><i class="fas fa-comments-dollar"></i> Economic or Environmental Interests</b><br>
                         <span class="text-muted small">{{c.economic_interests}}</span>
                         <br>
                         {% endif %}
                         {% if c.other_considerations %}
-                        <b><i class="fas fa-users"></i> Other Interests</b><br>
+                        <b><i class="fas fa-users"></i> Community Needs and Concerns</b><br>
                         <span class="text-muted small">{{c.other_considerations}}</span>
                         <br>
                         {% endif %}

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -115,22 +115,22 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                           {% endif %}
                         </span>
                         {% if c.cultural_interests %}
-                        <b><i class="fas fa-palette"></i> Cultural Interests</b><br>
+                        <b><i class="fas fa-palette"></i> Cultural or Historical Interests</b><br>
                         <span class="text-muted small">{{c.cultural_interests}}</span>
                         <br>
                         {% endif %}
                         {% if c.comm_activities %}
-                        <b><i class="fas fa-hiking"></i> Community Activities</b><br>
+                        <b><i class="fas fa-hiking"></i> Community Activities and Services</b><br>
                         <span class="text-muted small">{{c.comm_activities}}</span>
                         <br>
                         {% endif %}
                         {% if c.economic_interests %}
-                        <b><i class="fas fa-comments-dollar"></i> Economic Interests</b><br>
+                        <b><i class="fas fa-comments-dollar"></i> Economic or Environmental Interests</b><br>
                         <span class="text-muted small">{{c.economic_interests}}</span>
                         <br>
                         {% endif %}
                         {% if c.other_considerations %}
-                        <b><i class="fas fa-users"></i> Other Interests</b><br>
+                        <b><i class="fas fa-users"></i> Community Needs and Concerns</b><br>
                         <span class="text-muted small">{{c.other_considerations}}</span>
                         <br>
                         {% endif %}

--- a/main/templates/main/review.html
+++ b/main/templates/main/review.html
@@ -76,22 +76,22 @@
                 <span class="font-weight-light comm-content">
                   <span class="more-content">
                     {% if c.cultural_interests %}
-                    <b><i class="fas fa-palette"></i> Cultural Interests</b><br>
+                    <b><i class="fas fa-palette"></i> Cultural or Historical Interests</b><br>
                     <span class="text-muted small">{{c.cultural_interests}}</span>
                     <br>
                     {% endif %}
                     {% if c.comm_activities %}
-                    <b><i class="fas fa-hiking"></i> Community Activities</b><br>
+                    <b><i class="fas fa-hiking"></i> Community Activities and Services</b><br>
                     <span class="text-muted small">{{c.comm_activities}}</span>
                     <br>
                     {% endif %}
                     {% if c.economic_interests %}
-                    <b><i class="fas fa-comments-dollar"></i> Economic Interests</b><br>
+                    <b><i class="fas fa-comments-dollar"></i> Economic or Environmental Interests</b><br>
                     <span class="text-muted small">{{c.economic_interests}}</span>
                     <br>
                     {% endif %}
                     {% if c.other_considerations %}
-                    <b><i class="fas fa-users"></i> Other Interests</b><br>
+                    <b><i class="fas fa-users"></i> Community Needs and Concerns</b><br>
                     <span class="text-muted small">{{c.other_considerations}}</span>
                     <br>
                     {% endif %}

--- a/main/templates/main/submission-copy.html
+++ b/main/templates/main/submission-copy.html
@@ -102,22 +102,22 @@
                             </span>
                           </span>
                           {% if c.cultural_interests %}
-                          <b><i class="fas fa-palette"></i> Cultural Interests</b><br>
+                          <b><i class="fas fa-palette"></i> Cultural or Historical Interests</b><br>
                           <span class="text-muted small">{{c.cultural_interests}}</span>
                           <br>
                           {% endif %}
                           {% if c.comm_activities %}
-                          <b><i class="fas fa-hiking"></i> Community Activities</b><br>
+                          <b><i class="fas fa-hiking"></i> Community Activities and Services</b><br>
                           <span class="text-muted small">{{c.comm_activities}}</span>
                           <br>
                           {% endif %}
                           {% if c.economic_interests %}
-                          <b><i class="fas fa-comments-dollar"></i> Economic Interests</b><br>
+                          <b><i class="fas fa-comments-dollar"></i> Economic or Environmental Interests</b><br>
                           <span class="text-muted small">{{c.economic_interests}}</span>
                           <br>
                           {% endif %}
                           {% if c.other_considerations %}
-                          <b><i class="fas fa-users"></i> Other Interests</b><br>
+                          <b><i class="fas fa-users"></i> Community Needs and Concerns</b><br>
                           <span class="text-muted small">{{c.other_considerations}}</span>
                           <br>
                           {% endif %}
@@ -177,7 +177,7 @@
                 </div>
         </nav>
             </div>
-          
+
           <!-- The map -->
           <div class="col-md-8 col-map col-wide">
               <div id='map' class="map-visualization">

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -154,7 +154,7 @@
             </div>
             <div class="accordion map-info-item mt-3 mb-3" id="mobile-map-other-interests-accordion">
                 <button class="btn btn-link text-left comm-item-text pl-3 no-underline-link" type="button" data-target="#mobile-map-other-interests-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
-                    {% trans "Other Interests and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
+                    {% trans "Community Needs and Concerns" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>
                 </button>
                 <div id="mobile-map-other-interests-resp" class="collapse pl-3 pb-1" aria-labelledby="mobile-map-other-interests-accordion" data-parent="#mobile-map-other-interests-accordion">
                     <p class="collapse-in map-survey-response">


### PR DESCRIPTION
**changes**
- when erasing on the map, checks for contiguity
- if erase would lead to a non-contiguous selection, displays an error message and doesn't allow the user to erase

**to test**
- python manage.py runserver
- go to mapping page
- create a contiguous selection
- try to erase a block in the middle that would lead to a non-contiguous community
- check error message appears and you aren't allowed to erase

**note**
- as with the contiguity feature from before, there are occasional edge cases where you can end up with a non contiguous community. this is due to the irregular nature of census block groups