### PR TITLE
visualizations: line thickness, colors, COI outlines

### DIFF
--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -15,6 +15,17 @@ var BOUNDARIES_LAYERS = {
   "pos4": "5-digit Postcode Areas",
   "sta5": "Census Block Groups"
 }
+var BOUNDARIES_COLORS = {
+  "leg2": "rgb(60, 180, 75)", // green
+  "leg3": "rgb(245, 130, 49)", // orange
+  "leg4": "rgb(145, 30, 180)", // purple
+  "adm2": "rgb(230, 25, 75)", // red
+  "pos4": "rgb(67, 99, 216)", // blue
+  "sta5": "rgb(128, 128, 0)", // olive
+  "school": "rgb(70, 153, 144)", // teal
+  "chi-ward": "rgb(0, 0, 117)", // navy
+  "chi-comm": "rgb(169, 169, 169)" // gray
+}
 var BG_KEYS = {
   "albg": "300jwyj1",
   "akbg": "6tvgdw55",

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -78,6 +78,7 @@ function newBoundariesLayer(name) {
       },
       paint: {
         "line-color": "rgba(106,137,204,0.7)",
+        "line-width": 2,
       }
     }
   );
@@ -110,6 +111,7 @@ map.on("load", function () {
       },
       paint: {
         "line-color": "rgba(106,137,204,0.7)",
+        "line-width": 2,
       },
     }
   );
@@ -128,6 +130,7 @@ map.on("load", function () {
         },
         paint: {
           "line-color": "rgba(106,137,204,0.7)",
+          "line-width": 2,
         },
       }
     );
@@ -142,6 +145,7 @@ map.on("load", function () {
         },
         paint: {
           "line-color": "rgba(106,137,204,0.7)",
+          "line-width": 2,
         },
       }
     );
@@ -212,21 +216,22 @@ map.on("load", function () {
           'fill-opacity': 0.15
       },
   });
-  map.addLayer({
-      'id': 'coi_layer_line',
-      'type': 'line',
-      'source': 'coi_all',
-      'paint': {
-          'line-color': '#808080',
-          'line-width': 2
-      },
-  });
-  
+  // map.addLayer({
+  //     'id': 'coi_layer_line',
+  //     'type': 'line',
+  //     'source': 'coi_all',
+  //     'paint': {
+  //         'line-color': '#808080',
+  //         'line-width': 2
+  //     },
+  // });
+
   // console.log('finsihed layers');
 
   // hover to highlight
   $(".community-review-span").hover(function() {
     let highlight_id = this.id + "_boldline";
+    let highlight_id_fill = this.id + "_fill";
     map.addSource(highlight_id, {
         'type': 'geojson',
         'data': {
@@ -240,16 +245,26 @@ map.on("load", function () {
         'tolerance': tol // def .375 higher = simpler geometry
     });
     map.addLayer({
+        'id': highlight_id_fill,
+        'type': 'fill',
+        'source': highlight_id,
+        'paint': {
+          'fill-color': 'rgb(110, 178, 181)',
+          'fill-opacity': 0.15
+        },
+    });
+    map.addLayer({
         'id': highlight_id,
         'type': 'line',
         'source': highlight_id,
         'paint': {
-            'line-color': '#000000',
-            'line-width': 4
+          'line-color': '#808080',
+          'line-width': 2,
         },
     });
   }, function () {
     map.removeLayer(this.id+"_boldline");
+    map.removeLayer(this.id+"_fill");
     map.removeSource(this.id+"_boldline");
   });
 

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -77,7 +77,8 @@ function newBoundariesLayer(name) {
         visibility: "none"
       },
       paint: {
-        "line-color": "rgba(106,137,204,0.7)",
+        "line-color": BOUNDARIES_COLORS[name],
+        "line-opacity": 0.7,
         "line-width": 2,
       }
     }
@@ -110,7 +111,8 @@ map.on("load", function () {
         visibility: "none",
       },
       paint: {
-        "line-color": "rgba(106,137,204,0.7)",
+        "line-color": BOUNDARIES_COLORS["school"],
+        "line-opacity": 0.7,
         "line-width": 2,
       },
     }
@@ -129,7 +131,8 @@ map.on("load", function () {
           visibility: "none",
         },
         paint: {
-          "line-color": "rgba(106,137,204,0.7)",
+          "line-color": BOUNDARIES_COLORS["chi-ward"],
+          "line-opacity": 0.7,
           "line-width": 2,
         },
       }
@@ -144,7 +147,8 @@ map.on("load", function () {
           visibility: "none",
         },
         paint: {
-          "line-color": "rgba(106,137,204,0.7)",
+          "line-color": BOUNDARIES_COLORS["chi-comm"],
+          "line-opacity": 0.7,
           "line-width": 2,
         },
       }
@@ -216,15 +220,6 @@ map.on("load", function () {
           'fill-opacity': 0.15
       },
   });
-  // map.addLayer({
-  //     'id': 'coi_layer_line',
-  //     'type': 'line',
-  //     'source': 'coi_all',
-  //     'paint': {
-  //         'line-color': '#808080',
-  //         'line-width': 2
-  //     },
-  // });
 
   // console.log('finsihed layers');
 


### PR DESCRIPTION
**changes**
- increased the thickness of data layers on visualization pages
- removed COI outlines
- edited hover impact on COI view to be more emphatic
- added different colors for data layers (question: do we want to limit people to only having one data layer visible at a time?
- 
**to test**
- python manage.py runserver
- go to map page (preferably one with many overlapping COIs)
- check data layers, aesthetics, no errors, etc

**screenshots**
two overlapping communities with no borders:
![image](https://user-images.githubusercontent.com/41943646/107703937-86d99a00-6c60-11eb-8154-f20ad0010795.png)
hovering over one of the two:
![image](https://user-images.githubusercontent.com/41943646/107703969-9658e300-6c60-11eb-9e15-5d696dc54a4e.png)
congressional districts:
![image](https://user-images.githubusercontent.com/41943646/107704049-b8eafc00-6c60-11eb-8130-afce0f6b9832.png)
state house districts:
![image](https://user-images.githubusercontent.com/41943646/107704072-c4d6be00-6c60-11eb-9e81-c1cb6c07a922.png)

(not going to upload a pic of each layer but you get the point. each one is a different color)