### PR TITLE
Entry page small changes + bugfixes

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -1296,6 +1296,13 @@ Entry Form Management
   background: #DAEFFF;
   opacity: 0.5;
   border: none;
+  outline: none;
+}
+.survey-field:focus {
+  background: #DAEFFF;
+  opacity: 0.5;
+  border: none;
+  outline: none;
 }
 
 .entry-step {

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -437,6 +437,28 @@ $("#entry_address_button").on("click", function(e) {
   }
 });
 
+// these check for a user clicking on the text box and open examples
+$("#id_economic_interests").on("click", function(e) {
+  if (!$('#economic_interests_example').hasClass("show")) {
+    $('#economic_interests_btn').click();
+  }
+});
+$("#id_comm_activities").on("click", function(e) {
+  if (!$('#comm_activities_example').hasClass("show")) {
+    $('#comm_activities_btn').click();
+  }
+});
+$("#id_cultural_interests").on("click", function(e) {
+  if (!$('#cultural_interests_example').hasClass("show")) {
+    $('#cultural_interests_btn').click();
+  }
+});
+$("#id_other_considerations").on("click", function(e) {
+  if (!$('#other_interests_example').hasClass("show")) {
+    $('#other_interests_btn').click();
+  }
+});
+
 function interestsValidated() {
   var flag = true;
   var cultural_interests_field = document.getElementById(

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -386,6 +386,10 @@ map.on("load", function () {
     setTimeout(emailPDF, 5000);
   });
   if (is_thanks === "True") {
+    history.pushState(null, null, document.URL);
+    window.addEventListener('popstate', function () {
+        history.pushState(null, null, document.URL);
+    });
     canOnlyFireOnce(); // "Fired!"
   }
 

--- a/main/templates/main/entry_survey.html
+++ b/main/templates/main/entry_survey.html
@@ -274,7 +274,7 @@
                 <!-- Form Errors END -->
                 <!-- Sections: -->
                 <!--  Economic -->
-                <button class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#economic_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                <button id="economic_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#economic_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
                     <h5 class="survey-sect-title">{% trans "Economic or Environmental Interests" %}<i class="fas fa-angle-down pl-3"></i></h5>
                 </button>
                 <div class="accordion" id="economic_interests_accordion">
@@ -293,7 +293,7 @@
                 {{ comm_form.economic_interests|append_attr:"class:form-control survey-field" }}
                 <!-- Activities -->
                 <div class="accordion" id="comm_activities_accordion">
-                    <button class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#comm_activities_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                    <button id="comm_activities_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#comm_activities_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
                         <h5 class="survey-sect-title">{% trans "Community Activities and Services" %}<i class="fas fa-angle-down pl-3"></i></h5>
                     </button>
                     <div id="comm_activities_example" class="collapse" aria-labelledby="comm_activities_accordion" data-parent="#comm_activities_accordion">
@@ -312,7 +312,7 @@
 
                 <!-- Cultural -->
                 <div class="accordion" id="cultural_interests_accordion">
-                    <button class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#cultural_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                    <button id="cultural_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#cultural_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
                         <h5 class="survey-sect-title">{% trans "Cultural or Historical Interests" %}<i class="fas fa-angle-down pl-3"></i></h5>
                     </button>
                     <div id="cultural_interests_example" class="collapse" aria-labelledby="cultural_interests_accordion" data-parent="#cultural_interests_accordion">
@@ -330,7 +330,7 @@
                 {{ comm_form.cultural_interests|append_attr:"class:form-control survey-field" }}
                 <!-- Other -->
                 <div class="accordion" id="other_interests_accordion">
-                    <button class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#other_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                    <button id="other_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#other_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
                         <h5 class="survey-sect-title">{% trans "Community Needs and Concerns" %}<i class="fas fa-angle-down pl-3"></i></h5>
                     </button>
                     <div id="other_interests_example" class="collapse" aria-labelledby="other_interests_accordion" data-parent="#other_interests_accordion">


### PR DESCRIPTION
**changes**
- clicking on a text box automatically opens up the examples, if not already visible
- text box remains blue when typing
- blocks using the back button after submitting a community

**to test**
- python manage.py runserver
- add your community
- on survey page, check for expected behavior
- after submitting community, check that back button is blocked