### PR TITLE
two entry page bugfixes

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -905,10 +905,37 @@ Entry Mapping Page
 
 #map-bottom-row {
   position: absolute;
-  z-index: 1;
   bottom: 20%;
   width:100%;
   left: 0;
+}
+
+#mapToPrivacy {
+  position: absolute;
+  z-index: 1;
+  right: 34.8%;
+  bottom: 20%;
+}
+
+#mapToSurveyP2 {
+  position: absolute;
+  z-index: 1;
+  left: 34.8%;
+  bottom: 20%;
+}
+
+#mapToPrivacyMobile {
+  position: absolute;
+  z-index: 1;
+  right: 22%;
+  bottom: 20%;
+}
+
+#mapToSurveyP2Mobile {
+  position: absolute;
+  z-index: 1;
+  left: 22%;
+  bottom: 20%;
 }
 
 #mobile-map-help-btn:not(.opened),

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -192,10 +192,6 @@ $('#map-comm-modal').on('shown.bs.modal hidden.bs.modal', function() {
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
 function animateStepForward(at, to, after) {
-  console.log("animatestepforward");
-  console.log("at: " + at);
-  console.log("to: " + to);
-  console.log("after: " + after);
   mobileTxt = "Mobile";
 
   completedBarId = "#" + at + "to" + to;
@@ -225,10 +221,6 @@ function animateStepForward(at, to, after) {
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
 function animateStepBackward(at, to, next) {
-  console.log("animatestepbackward");
-  console.log("at: " + at);
-  console.log("to: " + to);
-  console.log("next: " + next);
   mobileTxt = "Mobile";
   if (next != null) {
     currentBarId = "#" + at + "to" + next;
@@ -261,7 +253,6 @@ function addressToSurveyStart() {
 }
 
 function surveyStartToAddress() {
-  console.log("surveystarttoaddress");
   $("#entry_survey").addClass("d-none");
   $("#entry_address").removeClass("d-none");
   animateStepBackward(2, 1, 3);

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -558,6 +558,10 @@ $("#mapToPrivacyMobile").on("click", function(e) {
   }
 })
 
+$("#mapToSurveyP2").click(mapToSurveyP2);
+
+$("#mapToSurveyP2Mobile").click(mapToSurveyP2);
+
 function privacyCheckValidation() {
   if (document.getElementById("toc_check").checked === true || document.getElementById("toc_check_xl").checked === true) {
     $("#need_privacy").addClass("d-none");

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -192,6 +192,10 @@ $('#map-comm-modal').on('shown.bs.modal hidden.bs.modal', function() {
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
 function animateStepForward(at, to, after) {
+  console.log("animatestepforward");
+  console.log("at: " + at);
+  console.log("to: " + to);
+  console.log("after: " + after);
   mobileTxt = "Mobile";
 
   completedBarId = "#" + at + "to" + to;
@@ -221,6 +225,10 @@ function animateStepForward(at, to, after) {
  * right now those bars have been left out so those lines can be deleted if the bars won't be put back in
 */
 function animateStepBackward(at, to, next) {
+  console.log("animatestepbackward");
+  console.log("at: " + at);
+  console.log("to: " + to);
+  console.log("next: " + next);
   mobileTxt = "Mobile";
   if (next != null) {
     currentBarId = "#" + at + "to" + next;
@@ -253,6 +261,7 @@ function addressToSurveyStart() {
 }
 
 function surveyStartToAddress() {
+  console.log("surveystarttoaddress");
   $("#entry_survey").addClass("d-none");
   $("#entry_address").removeClass("d-none");
   animateStepBackward(2, 1, 3);
@@ -331,6 +340,13 @@ function privacyToMap() {
   animateStepBackward(4, 3, 5);
   automaticScrollToTop();
 }
+
+$("#entrySubmissionButton").keypress(
+  function(event){
+    if (event.which == '13') {
+      event.preventDefault();
+    }
+});
 
 
 function clearFieldsError(fields) {

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -55,6 +55,7 @@
 {% block content %}
 <!-- Entry Form -->
 <form id="entryForm" method="post" onSubmit="return validateRecaptcha();">
+  <button type="submit" disabled style="display: none" aria-hidden="true"></button>
     {% csrf_token %}
     <div id="main_community_form" class="form-group">
         <!-- {# Include the hidden fields #} -->

--- a/main/templates/main/entry_map.html
+++ b/main/templates/main/entry_map.html
@@ -169,7 +169,7 @@
                 <!-- Help Button and Dropdown -->
                 <div class="col-1 text-md-right align-middle d-none d-md-block">
                     <div id="map-help-dropdown" class="dropdown text-md-right">
-                        <button id="map-help-btn" class="btn btn-outline-primary btn-circle btn-md mapping-icon mapping-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">?</button>
+                        <button id="map-help-btn" type="button" class="btn btn-outline-primary btn-circle btn-md mapping-icon mapping-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">?</button>
 
                         <div id="map-help-menu" class="dropdown-menu vw-md-75 vw-lg-50" aria-labelledby="map-help-btn">
                             <div class="container pl-5 pr-5 pb-5 h-100">
@@ -230,7 +230,7 @@
                 <!-- Community Button and Dropdown -->
                 <div id="map-comm-info" class="col-1 col-md-4 col-lg-3 col-xl-2 d-md-block">
                     <div id="map-comm-dropdown" class="dropdown text-md-left">
-                        <button class="btn btn-primary d-none d-md-inline-block mapping-icon mapping-btn" data-toggle="dropdown" style="border-radius: .5rem;" id="map-comm-btn" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="btn btn-primary d-none d-md-inline-block mapping-icon mapping-btn" data-toggle="dropdown" style="border-radius: .5rem;" id="map-comm-btn" aria-haspopup="true" aria-expanded="false">
                             {% blocktrans %}
                                 Community Information
                             {% endblocktrans %}
@@ -287,10 +287,10 @@
                 <div class="col-1 d-md-none p-0">
                     <div class="row pt-3">
                         <div class="col-12 text-center pl-0">
-                            <button id="mobile-map-help-btn" class="btn btn-outline-primary btn-circle btn-md mapping-icon mapping-btn">?</button>
+                            <button id="mobile-map-help-btn" type="button" class="btn btn-outline-primary btn-circle btn-md mapping-icon mapping-btn">?</button>
                         </div>
                         <div class="col-12 text-center pl-0 pt-2">
-                            <button id="mobile-map-comm-btn" class="btn btn-primary mapping-icon mapping-btn" style="border-radius: .5rem;" data-toggle="dropdown" style="border-radius: .5rem;" id="map-comm-btn" aria-haspopup="true" aria-expanded="false">
+                            <button id="mobile-map-comm-btn" type="button" class="btn btn-primary mapping-icon mapping-btn" style="border-radius: .5rem;" data-toggle="dropdown" style="border-radius: .5rem;" id="map-comm-btn" aria-haspopup="true" aria-expanded="false">
                                 {% blocktrans %}
                                     +
                                 {% endblocktrans %}
@@ -312,12 +312,12 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col text-center d-none d-lg-block">
-                    <button class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
-                    <button id="mapToPrivacy" class="btn btn-primary btn-lg no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
+                    <button type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToPrivacy" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
                 <div class="col text-center d-lg-none">
-                    <button class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
-                    <button id="mapToPrivacyMobile" class="btn btn-primary no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
+                    <button type="button" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToPrivacyMobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
             </div>
         </div>

--- a/main/templates/main/entry_map.html
+++ b/main/templates/main/entry_map.html
@@ -312,11 +312,11 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col text-center d-none d-lg-block">
-                    <button id="mapToSurveyP2" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacy" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
                 <div class="col text-center d-lg-none">
-                    <button id="mapToSurveyP2Mobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2Mobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacyMobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
             </div>

--- a/main/templates/main/entry_map.html
+++ b/main/templates/main/entry_map.html
@@ -312,11 +312,11 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col text-center d-none d-lg-block">
-                    <button type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacy" type="button" class="btn btn-primary btn-lg no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
                 <div class="col text-center d-lg-none">
-                    <button type="button" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2Mobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacyMobile" type="button" class="btn btn-primary no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
             </div>

--- a/main/templates/main/entry_survey.html
+++ b/main/templates/main/entry_survey.html
@@ -118,8 +118,8 @@
                 </div>
                 <div class="row d-none d-xl-flex pt-4">
                     <div class="col text-center">
-                        <button class="btn btn-outline-primary no-underline-link entry-nav-btn mr-4" onclick="surveyStartToAddress()"><i class="fas fa-angle-left pr-2" type="button"></i>{% trans "BACK" %}</button>
-                        <button class="btn btn-primary no-underline-link entry-nav-btn ml-4" onclick="startSurvey()" type="button">{% trans "START" %}<i class="fas fa-angle-right pl-2"></i></button>
+                        <button type="button" class="btn btn-outline-primary no-underline-link entry-nav-btn mr-4" onclick="surveyStartToAddress()"><i class="fas fa-angle-left pr-2" type="button"></i>{% trans "BACK" %}</button>
+                        <button type="button" class="btn btn-primary no-underline-link entry-nav-btn ml-4" onclick="startSurvey()" type="button">{% trans "START" %}<i class="fas fa-angle-right pl-2"></i></button>
                     </div>
                 </div>
             </div>
@@ -216,8 +216,8 @@
                 </div>
                 <div class="row">
                     <div class="col text-center">
-                        <button class="btn btn-outline-primary no-underline-link entry-nav-btn mr-4" onclick="surveyStartToAddress()" type="button"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
-                        <button class="btn btn-primary no-underline-link entry-nav-btn ml-4" onclick="startSurvey()" type="button">{% trans "START" %}<i class="fas fa-angle-right pl-2"></i></button>
+                        <button type="button" class="btn btn-outline-primary no-underline-link entry-nav-btn mr-4" onclick="surveyStartToAddress()" type="button"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                        <button type="button" class="btn btn-primary no-underline-link entry-nav-btn ml-4" onclick="startSurvey()" type="button">{% trans "START" %}<i class="fas fa-angle-right pl-2"></i></button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**changes**
- fixed bug where if you pressed enter when searching for a place to start on map page, it would result in you seeing both the address portion of the survey page as well as the privacy portion at the same page (problem: buttons needed to have type="button" so they wouldn't be form focused, and added a dummy button with type="submit" in form so that pressing enter doesn't trigger form validation
- fixed bug where users couldn't select units on the same line as the "back" and "next" buttons on map page

**to test**
- python manage.py runserver
- go thru survey user flow
- on map page, search for a zip code then press enter key
- select units on map page that were on the same line as the next button
- click next
- check no errors