### PR TITLE
2020 blockgroups : mi, nm, nv, nc, pa, ut, wa

### DIFF
--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -55,7 +55,7 @@ var BG_KEYS = {
   "mobg": "0h5galqm",
   "mtbg": "750skieu",
   "nebg": "3ppwl6ix",
-  "nvbg": "0dgcp7py",
+  "nvbg": "8s8o0386", //2010: 0dgcp7py
   "nhbg": "1h5rofgu",
   "njbg": "9va600u8",
   "nmbg": "2r4kzila", //2010: bbx551ad

--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -82,4 +82,4 @@ var BG_KEYS = {
 var CHI_WARD_KEY = "179v2oeh";
 var CHI_COMM_KEY = "63nswxfc";
 var SCHOOL_DISTR_KEY = "1ezqvmlm";
-var STATES_USING_NEW_BG = ["mi", "nm", "nc", "pa", "ut", "va", "wa"];
+var STATES_USING_NEW_BG = ["mi", "nv", "nm", "nc", "pa", "ut", "va", "wa"];

--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -57,7 +57,7 @@ var BG_KEYS = {
   "nebg": "3ppwl6ix",
   "nvbg": "8s8o0386", //2010: 0dgcp7py
   "nhbg": "1h5rofgu",
-  "njbg": "9va600u8",
+  "njbg": "cxptfxf4", //2010: 9va600u8
   "nmbg": "2r4kzila", //2010: bbx551ad
   "nybg": "7xcrytdf", //2010: 7xcrytdf
   "ncbg": "1amgtw27", //2010: cexlxubg
@@ -82,4 +82,4 @@ var BG_KEYS = {
 var CHI_WARD_KEY = "179v2oeh";
 var CHI_COMM_KEY = "63nswxfc";
 var SCHOOL_DISTR_KEY = "1ezqvmlm";
-var STATES_USING_NEW_BG = ["mi", "nv", "nm", "nc", "pa", "ut", "va", "wa"];
+var STATES_USING_NEW_BG = ["mi", "nv", "nj", "nm", "nc", "pa", "ut", "va", "wa"];

--- a/main/static/main/js/components/keys.js
+++ b/main/static/main/js/components/keys.js
@@ -49,7 +49,7 @@ var BG_KEYS = {
   "mebg": "6epxgjkx",
   "mdbg": "92jrtgxz",
   "mabg": "b74lbqvs",
-  "mibg": "6rmkafit",
+  "mibg": "1isev57e", //2010: 6rmkafit
   "mnbg": "37vpwigo",
   "msbg": "ajbh778v",
   "mobg": "0h5galqm",
@@ -58,23 +58,23 @@ var BG_KEYS = {
   "nvbg": "0dgcp7py",
   "nhbg": "1h5rofgu",
   "njbg": "9va600u8",
-  "nmbg": "bbx551ad",
-  "nybg": "7xcrytdf",
-  "ncbg": "cexlxubg",
+  "nmbg": "2r4kzila", //2010: bbx551ad
+  "nybg": "7xcrytdf", //2010: 7xcrytdf
+  "ncbg": "1amgtw27", //2010: cexlxubg
   "ndbg": "4jpxsqxa",
   "ohbg": "6bunasmx",
   "okbg": "dlg7zdn0",
   "orbg": "13ookshu",
-  "pabg": "cpap9ug0",
+  "pabg": "bias7ts6", //2010: cpap9ug0
   "ribg": "564jbkj2",
   "scbg": "717b0zsq",
   "sdbg": "cklc8t21",
   "tnbg": "a8a1139u",
   "txbg": "9onkqc5t",
-  "utbg": "3i55e9ql",
+  "utbg": "bbpdc27n", //2010: 3i55e9ql
   "vtbg": "bzcxijma",
   "vabg": "2qpo9fjv", //2010: 5qxcnhry
-  "wabg": "9nxwrro5",
+  "wabg": "bnrqxpjq", //2010: 9nxwrro5
   "wvbg": "1ya1ngou",
   "wibg": "7pmyno56",
   "wybg": "0q0iu141"
@@ -82,4 +82,4 @@ var BG_KEYS = {
 var CHI_WARD_KEY = "179v2oeh";
 var CHI_COMM_KEY = "63nswxfc";
 var SCHOOL_DISTR_KEY = "1ezqvmlm";
-var STATES_USING_NEW_BG = ["va"];
+var STATES_USING_NEW_BG = ["mi", "nm", "nc", "pa", "ut", "va", "wa"];


### PR DESCRIPTION
**changes**
- switches Michigan, New Mexico, North Carolina, Pennsylvania, Nevada, Utah, and Washington to 2020 Census block groups, as per partner feedback

**to test**
- python manage.py runserver
- try drawing a COI in any of these states
- check no errors
