### PR TITLE
restore bugfixes: enter when mapping, selecting units on mapping page

### DIFF
--- a/main/static/main/css/style.css
+++ b/main/static/main/css/style.css
@@ -908,10 +908,37 @@ Entry Mapping Page
 
 #map-bottom-row {
   position: absolute;
-  z-index: 1;
   bottom: 20%;
   width:100%;
   left: 0;
+}
+
+#mapToPrivacy {
+  position: absolute;
+  z-index: 1;
+  right: 34.8%;
+  bottom: 20%;
+}
+
+#mapToSurveyP2 {
+  position: absolute;
+  z-index: 1;
+  left: 34.8%;
+  bottom: 20%;
+}
+
+#mapToPrivacyMobile {
+  position: absolute;
+  z-index: 1;
+  right: 22%;
+  bottom: 20%;
+}
+
+#mapToSurveyP2Mobile {
+  position: absolute;
+  z-index: 1;
+  left: 22%;
+  bottom: 20%;
 }
 
 #mobile-map-help-btn:not(.opened),

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -563,6 +563,10 @@ $("#mapToPrivacyMobile").on("click", function(e) {
   }, 2000);
 })
 
+$("#mapToSurveyP2").click(mapToSurveyP2);
+
+$("#mapToSurveyP2Mobile").click(mapToSurveyP2);
+
 function privacyCheckValidation() {
   if (document.getElementById("toc_check").checked === true || document.getElementById("toc_check_xl").checked === true) {
     $("#need_privacy").addClass("d-none");

--- a/main/templates/main/entry.html
+++ b/main/templates/main/entry.html
@@ -55,6 +55,7 @@
 {% block content %}
 <!-- Entry Form -->
 <form id="entryForm" method="post" onSubmit="return validateRecaptcha();">
+  <button type="submit" disabled style="display: none" aria-hidden="true"></button>
     {% csrf_token %}
     <div id="main_community_form" class="form-group">
         <!-- {# Include the hidden fields #} -->

--- a/main/templates/main/entry_map.html
+++ b/main/templates/main/entry_map.html
@@ -318,11 +318,11 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col text-center d-none d-lg-block">
-                    <button class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2" class="btn btn-primary btn-lg no-underline-link entry-nav-btn mr-4 mapping-icon"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacy" class="btn btn-primary btn-lg no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
                 <div class="col text-center d-lg-none">
-                    <button class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon" onclick="mapToSurveyP2()"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
+                    <button id="mapToSurveyP2Mobile" class="btn btn-primary no-underline-link entry-nav-btn mr-4 mapping-icon"><i class="fas fa-angle-left pr-2"></i>{% trans "BACK" %}</button>
                     <button id="mapToPrivacyMobile" class="btn btn-primary no-underline-link entry-nav-btn ml-4 mapping-icon">{% trans "SAVE" %}<i class="fas fa-angle-right pl-2"></i></button>
                 </div>
             </div>


### PR DESCRIPTION
**changes**
- restored bugfixes that got overwritten: pressing enter on modal on mapping page no longer results in multiple steps showing at once, can now select units in the same line as the back and save buttons when mapping