### PR TITLE
Add Organizations to Django Admin (for verification)

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -29,7 +29,7 @@ from django.utils.html import format_html
 from django import forms
 from ckeditor.widgets import CKEditorWidget
 
-from .models import State, Drive, FrequentlyAskedQuestion, GlossaryDefinition
+from .models import State, Drive, FrequentlyAskedQuestion, GlossaryDefinition, Organization
 
 
 class StateAdminForm(forms.ModelForm):
@@ -181,3 +181,5 @@ class CommunityAdmin(ImportExportModelAdmin):
 
 
 admin.site.register(CommunityEntry, CommunityAdmin)
+
+admin.site.register(Organization)


### PR DESCRIPTION
**changes**
- adds organizations to django admin, from which anyone with admin access can add verification

**to test**
- python manage.py runserver
- go to http://127.0.0.1:8000/admin/
- go to Organizations
- change an org to Verified = true by checking the checkbox
- check that org appears verified on site!

**screenshots**
![image](https://user-images.githubusercontent.com/41943646/112651971-4c4c4b00-8e23-11eb-8963-1f4a236661ce.png)
