### PR TITLE
need to provide admin email to add administrators to org

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -265,13 +265,16 @@ class DriveForm(ModelForm):
 class MemberForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(MemberForm, self).__init__(*args, **kwargs)
-        self.fields["member"].widget.attrs.update({"class": "form-control"})
+        member_email = forms.EmailField(max_length = 200)
+        self.fields["email"] = member_email
+        self.fields["email"].widget.attrs.update({"placeholder": "Admin Email", "class": "form-control"})
 
     class Meta:
         model = Membership
         fields = [
             "member",
         ]
+        exclude = ("member",)
 
 
 class RepresentableSignupForm(SignupForm):

--- a/main/templates/main/dashboard/partners/index.html
+++ b/main/templates/main/dashboard/partners/index.html
@@ -3,7 +3,20 @@
 
 {% block content %}
 <div class="container">
-  <div class="row mt-5">
+  <div class="col-sm mt-4">
+    {% if messages %} 
+    <ul class="messages">
+      {% for message in messages %}
+        {% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
+        <div class="alert alert-success">
+          <strong>Admin email added!</strong>
+        </div>
+        {% endif %}
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+  <div class="row mt-1">
     <div class="col-sm">
       <div class="card shadow-sm h-100">
         <div class="card-body">

--- a/main/templates/main/dashboard/partners/member_form.html
+++ b/main/templates/main/dashboard/partners/member_form.html
@@ -22,7 +22,9 @@
                             {% if messages %}
                             <ul class="messages">
                                 {% for message in messages %}
-                                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                                    {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
+                                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                                    {% endif %}
                                 {% endfor %}
                             </ul>
                             {% endif %}

--- a/main/templates/main/dashboard/partners/member_form.html
+++ b/main/templates/main/dashboard/partners/member_form.html
@@ -19,6 +19,13 @@
                           <div class="form-group">
                         {% for field in form %}
                           <div class="fieldWrapper">
+                            {% if messages %}
+                            <ul class="messages">
+                                {% for message in messages %}
+                                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                                {% endfor %}
+                            </ul>
+                            {% endif %}
                               {{ field.errors }}
                               {{ field.label_tag }} {{ field }}
                               {% if field.help_text %}

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -319,7 +319,7 @@ class CreateMember(LoginRequiredMixin, OrgAdminRequiredMixin, FormView):
                 organization=form.instance.organization,
             )
             new_member.save()
-
+        messages.add_message(self.request, messages.SUCCESS, 'Admin added successfully!')
         self.success_url = reverse_lazy(
             "main:home_org", kwargs=form.instance.organization.get_url_kwargs()
         )

--- a/main/views/dashboard.py
+++ b/main/views/dashboard.py
@@ -287,9 +287,6 @@ class CreateMember(LoginRequiredMixin, OrgAdminRequiredMixin, FormView):
         context = super().get_context_data(**kwargs)
 
         members = Membership.objects.filter(organization__pk=self.kwargs["pk"])
-        print(members)
-        for item in members:
-            print(item.member)
         context["organization"] = Organization.objects.get(
             id=self.kwargs["pk"]
         )


### PR DESCRIPTION
**Changes**:
* removed the dropdown
* need to provide full email of admin
* shows error and reloads form if incorrect email or user does not exist
* redirects otherwise

**To test**:
* python manage.py runserver
* go to your org
* manage the org admins
* add more admins
* add the admin email
* check the admin page to see if they were added
* put in incorrect email and check if the error was displayed

![image](https://user-images.githubusercontent.com/15281033/112727047-e204da80-8ef6-11eb-9d64-6a216dbab72f.png)
