### PR TITLE
PDF export fixes

### DIFF
--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -231,7 +231,9 @@ map.on("load", function () {
       fit["_northEast"]["lng"]
     );
     var commBounds = new mapboxgl.LngLatBounds(southWest, northEast);
-    map.fitBounds(commBounds, { padding: 100 });
+    map.fitBounds(commBounds, {
+      padding: {top: 20, bottom:20, left: 50, right: 50}
+    });
     map.addLayer({
       id: obj,
       type: "fill",
@@ -297,7 +299,9 @@ map.on("load", function () {
   // TODO: add array of blockgroup ids, add population and other demographic info
   function exportPDF(delay) {
     // make the map look good for the PDF ! TODO: un-select other layers like census blocks (turn into functions)
-    map.fitBounds(commBounds, { padding: 100 });
+    map.fitBounds(commBounds, {
+      padding: {top: 20, bottom:20, left: 50, right: 50}
+    });
     // display loading popup
     var instruction_box = document.getElementById("pdf-loading-box");
     instruction_box.style.display = "block";
@@ -350,7 +354,9 @@ map.on("load", function () {
 
   function emailPDF() {
     // make the map look good for the PDF ! TODO: un-select other layers like census blocks (turn into functions)
-    map.fitBounds(commBounds, { padding: 100 });
+    map.fitBounds(commBounds, {
+      padding: {top: 20, bottom:20, left: 50, right: 50}
+    });
 
     // setup XMLH request
     var request = new XMLHttpRequest();

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -300,7 +300,8 @@ map.on("load", function () {
   function exportPDF(delay) {
     // make the map look good for the PDF ! TODO: un-select other layers like census blocks (turn into functions)
     map.fitBounds(commBounds, {
-      padding: {top: 20, bottom:20, left: 50, right: 50}
+      padding: {top: 20, bottom:20, left: 50, right: 50},
+      duration: 0
     });
     // display loading popup
     var instruction_box = document.getElementById("pdf-loading-box");
@@ -342,7 +343,8 @@ map.on("load", function () {
       doc.setFontSize(24);
       doc.text(20, 20, "Community Information");
       // entry fields
-      var entryInfo = window.document.getElementById("pdfInfo");
+      var entryInfo = $("#pdfInfo").prop('outerHTML');
+      entryInfo = entryInfo.replace(/[^\x00-\x7F]/g, "");
       doc.fromHTML(entryInfo, 20, 25, {
         width: 180,
       });
@@ -355,7 +357,8 @@ map.on("load", function () {
   function emailPDF() {
     // make the map look good for the PDF ! TODO: un-select other layers like census blocks (turn into functions)
     map.fitBounds(commBounds, {
-      padding: {top: 20, bottom:20, left: 50, right: 50}
+      padding: {top: 20, bottom:20, left: 50, right: 50},
+      duration: 0
     });
 
     // setup XMLH request


### PR DESCRIPTION
**changes**
- altered zoom to community on submission page to better fit the community on smaller resolution screens
- sanitized community information text to only include ASCII characters
- makes zoom instant for export to avoid strange pdfs if export button is immediately pressed before mapbox has time to zoom

**to test**
- python manage.py runserver
- create a community, include non ASCII characters in description
- export pdf on submission page (important: use a smaller resolution so that the map appears to have roughly a 2:1 aspect ratio
- check no errors

**screenshots**
the map
![image](https://user-images.githubusercontent.com/41943646/115727793-f3a09d00-a351-11eb-8805-77b2e0aa85a9.png)

pdf
![image](https://user-images.githubusercontent.com/41943646/115727947-103cd500-a352-11eb-9ea2-be7353df2780.png)
![image](https://user-images.githubusercontent.com/41943646/115727974-17fc7980-a352-11eb-9dae-43f549562dae.png)


