### PR TITLE
bugfix: ability to add to drive if not community author

### DIFF
--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -163,6 +163,7 @@
             </div>
           </div>
         </div>
+        {% if is_community_author %}
         <div class="card text-left border-0 w-100 rounded-lg mt-3 mb-3 d-xl-block">
           <div class="card-body">
             <h5 class="card-title header-text"><strong>Submit to an organization in your state</strong></h5>
@@ -175,7 +176,7 @@
                 {% endfor %}
                 <div class="row justify-content-center pt-3">
                   <div>
-                    <button type="submit" class="btn btn-primary">Submit</button>                    
+                    <button type="submit" class="btn btn-primary">Submit</button>
                   </div>
                 </div>
               </form>
@@ -184,6 +185,7 @@
             {% endif %}
           </div>
         </div>
+        {% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
fixes bug where an authenticated user can add another user's community to a drive

**to test**
- create a community
- copy url to submission page
- log out and log into different account
- go to submission page url
- check that no "add this community to an organization" card appears