### PR TITLE
add 404s for map pages

### DIFF
--- a/main/views/main.py
+++ b/main/views/main.py
@@ -800,10 +800,15 @@ class Map(TemplateView):
 
     def get_context_data(self, **kwargs):
         state = self.kwargs["state"].lower()
+        if not state:
+            raise Http404
 
         # the polygon coordinates
         entryPolyDict = dict()
-        state_obj = State.objects.get(abbr=state.upper())
+        try:
+            state_obj = State.objects.get(abbr=state.upper())
+        except:
+            raise Http404
         query = (
             state_obj.submissions.all()
             .defer("census_blocks_polygon_array", "user_polygon")

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -31,7 +31,7 @@ import geojson
 from django.shortcuts import get_object_or_404
 from geojson_rewind import rewind
 from django.core.serializers import serialize
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.urls import reverse_lazy
 
@@ -66,7 +66,10 @@ class PartnerMap(TemplateView):
         entryPolyDict = dict()
 
         # get the org to which this map belongs
-        org = Organization.objects.get(slug=self.kwargs["slug"])
+        try:
+            org = Organization.objects.get(slug=self.kwargs["slug"])
+        except:
+            raise Http404
 
         # get the user
         user = self.request.user
@@ -78,7 +81,10 @@ class PartnerMap(TemplateView):
 
         # get the polygon from db and pass it on to html
         if self.kwargs["drive"]:
-            drive = Drive.objects.get(slug=self.kwargs["drive"])
+            try:
+                drive = Drive.objects.get(slug=self.kwargs["drive"])
+            except:
+                raise Http404
             query = drive.submissions.all().defer(
                 "census_blocks_polygon_array", "user_polygon",
             ).prefetch_related("organization")


### PR DESCRIPTION
**changes**
- adds 404s when get() django functions return DoesNotExist: state map pages, org map pages, and drive map pages

**to test**
- python manage.py runserver
- test on nonexistent state: http://127.0.0.1:8000/map/xx/
- test on nonexistent org: http://127.0.0.1:8000/map/p/fake-org-link/
- test on nonexistent drive (with real org)