### PR TITLE
add exceptions for drive url errors

### DIFF
--- a/main/views/main.py
+++ b/main/views/main.py
@@ -963,7 +963,13 @@ class EntryView(LoginRequiredMixin, View):
         if kwargs["drive"]:
             has_drive = True
             drive_slug = self.kwargs["drive"]
-            drive = Drive.objects.get(slug=drive_slug)
+            try:
+                drive = Drive.objects.get(slug=drive_slug)
+            except:
+                raise Http404
+            if abbr.upper() != drive.state:
+                return redirect("/entry/drive/" + drive.slug + "/" + drive.state.lower())
+
             drive_name = drive.name
             drive_id = drive.id
             organization = drive.organization


### PR DESCRIPTION
**changes**
- added 404 for links to drives on entry page that don't exist
- added redirect when url is changes on entry page that includes a state

**to test**
- python manage.py runserver
- go to entry page drive link
- edit drive slug to be something fake (ex: illinois-drive -> illinois-drive-fake)
- check 404 appears
- go back to correct drive link
- change state abbreviation
- check redirect occurs