### PR TITLE
copy page link on submission + other various features

### DIFF
--- a/main/static/main/js/components/states.js
+++ b/main/static/main/js/components/states.js
@@ -175,5 +175,6 @@ let publicCommentLinks = {
   'nj': 'http://www.apportionmentcommission.org/ContactUs.asp',
   'ok': 'https://www.okhouse.gov/Publications/RedistrictingContacts.aspx',
   'tx': 'https://senate.texas.gov/redistrictingcomment/',
+  'wa': 'https://www.redistricting.wa.gov/submit-public-testimony',
   'wi': 'https://appengine.egov.com/apps/wi/peoplesmaps/writtencomment',
 }

--- a/main/static/main/js/submission.js
+++ b/main/static/main/js/submission.js
@@ -609,3 +609,21 @@ $("[data-toggle=modal]").on("click", function (e) {
 $("#geojson-explain-modal").on("show.bs.modal", function () {
   $("#hidden-download-geojson")[0].click();
 });
+
+// copies link to page to the clipboard
+// from: https://stackoverflow.com/questions/49618618/copy-current-url-to-clipboard
+function copyPageLink() {
+  var dummy = document.createElement('input'),
+      text = window.location.href;
+
+  document.body.appendChild(dummy);
+  dummy.value = text;
+  dummy.select();
+  document.execCommand('copy');
+  document.body.removeChild(dummy);
+
+  // set text to say "copied!" for feedback mechanism that the copying worked
+  var copyText = document.getElementById("copy-link-text");
+  copyText.innerHTML = "Copied!";
+  setTimeout(function () { copyText.innerHTML = 'Or <a href="#" onclick="copyPageLink();event.preventDefault();">copy the link</a> to this page to share.' }, 2000);
+}

--- a/main/templates/main/dashboard/drives/create.html
+++ b/main/templates/main/dashboard/drives/create.html
@@ -34,7 +34,9 @@
                             {% endfor %}
                         </div>
                         <div style="display: inline-block;">
-                          <p class="text-muted mx-2 pb-3">If you would like to include a custom question for users to answer when submitting a community to this mapping drive, please send us a request at <a href="mailto:team@representable.org">team@representable.org</a></p>
+                          <p class="text-muted mx-2 pb-3">By following this drive's custom link, users will be able to draw their community, after answering a series of questions.
+                            If you would like to include a custom question for users to answer when submitting a community to this mapping drive, please send us a request
+                            at <a href="mailto:team@representable.org">team@representable.org</a>.</p>
                           <button id="save" form="CreateDrive" type="submit" class="btn btn-primary" value="Submit">Submit</button>
                         </div>
                     </form>

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -132,6 +132,9 @@
                   <!-- ********************* -->
               </div>
             </div>
+            <p id="copy-link-text" class="header-text small mt-4 mb-0">
+              Or <a href="#" onclick="copyPageLink();event.preventDefault();">copy the link</a> to this page to share.
+            </p>
           </div>
         </div>
         <div class="card text-left border-0 w-100 rounded-lg mt-3">


### PR DESCRIPTION
**changes**
- added copy link on submission page, for folks who want to share their community via the custom link of their submission
- added the WA public input portal link to submission page for COIs drawn in the state
- update wording when creating a drive for clarity on custom drive questions

**to test**
- draw a community in WA
- check public input portal link appears on submission page
- check that "copy link" button underneath export buttons works as expected

**translations note**
- this adds two things for translation: the line on the submission page about copying a link, and the line on the drive creation page which now includes an extra sentence

**screenshots**
copy link (text changes to say "Copied!" for 1.5s after clicking
![image](https://user-images.githubusercontent.com/41943646/121052984-81104300-c780-11eb-9ebe-d9d197557793.png)
