### PR TITLE
fix frontend validation for survey questions

### DIFF
--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -562,13 +562,13 @@ function interestsValidated() {
     economic_interests_field.value == "" &&
     comm_activities_field.value == "" &&
     other_considerations_field.value == "" &&
-    (custom_response_field && custom_response_field.value == "")
+    (!custom_response_field || custom_response_field.value == "")
   ) {
     cultural_interests_field.classList.add("has_error");
     economic_interests_field.classList.add("has_error");
     comm_activities_field.classList.add("has_error");
     other_considerations_field.classList.add("has_error");
-    custom_response_field.classList.add("has_error");
+    if (custom_response_field) custom_response_field.classList.add("has_error");
     var interests_alert = document.getElementById("need_one_interest");
     interests_alert.classList.remove("d-none");
     flag = false;


### PR DESCRIPTION
**changes**
- makes it so that users cannot go to next step of survey flow if they leave all entries blank
- works for custom questions too

**to test**
- python manage.py runserver
- create a community, with no answers for survey questions
- check validation fails on frontend, stops user from advancing