### PR TITLE
displays and orders communities by date

### DIFF
--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -118,6 +118,8 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                             <span class="font-weight-light comm-content">
                               <span class="more-content">
                                 <span class="small">
+                                  <span class="text-muted">{{ c.created_at|date:"DATE_FORMAT" }}</span>
+                                  <br>
                                   {% if c.population > 0 %}
                                   <b>Population:</b> {{ c.population }}
                                   <br>

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -128,6 +128,8 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                           <span class="font-weight-light comm-content">
                             <span class="more-content">
                               <span class="small">
+                                <span class="text-muted">{{ c.created_at|date:"DATE_FORMAT" }}</span>
+                                <br>
                                 {% if c.population > 0 %}
                                 <b>Population:</b> {{ c.population }}
                                 <br>

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -615,7 +615,7 @@ class Submission(View):
                 context["verified"] = True
 
             elif(self.request.user.is_authenticated):
-                
+
                 user_email_confirmation = EmailConfirmationHMAC(
                     email_address=user_email_address
                 )
@@ -831,6 +831,7 @@ class Map(TemplateView):
             state_obj.submissions.all()
             .defer("census_blocks_polygon_array", "user_polygon")
             .prefetch_related("organization", "drive")
+            .order_by("-created_at")
         )
         # state map page --> drives in the state, entries without a drive but with a state
         drives = []

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -87,12 +87,13 @@ class PartnerMap(TemplateView):
                 raise Http404
             query = drive.submissions.all().defer(
                 "census_blocks_polygon_array", "user_polygon",
-            ).prefetch_related("organization")
+            ).prefetch_related("organization").order_by("-created_at")
+
         else:
             drive = None
             query = org.submissions.all().defer(
                 "census_blocks_polygon_array", "user_polygon"
-            ).prefetch_related("drive")
+            ).prefetch_related("drive").order_by("-created_at")
 
         # address information if admin/user drew the comms
         streets = {}


### PR DESCRIPTION
**changes**
- adds a date display on state map pages in the format like "Dec. 18, 2020"
- orders communities by date on all map pages -- most recently drawn communities show at the top of the list

**to test**
- go to state map page with multiple communities drawn
- check that date appears within "more info" dropdown
- check that dates are in order of most recent first
- check the same for a drive and organization map page

**screenshots**
![image](https://user-images.githubusercontent.com/41943646/122085633-8432b100-cdc8-11eb-8804-9dd946cac611.png)
