### PR TITLE
changes to export functionality

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -397,6 +397,9 @@ class CommunityEntry(models.Model):
     private = models.BooleanField(default=False, null=True)
     population = models.IntegerField(blank=True, null=True, default=0)
 
+    def human_readable_name(self):
+        return self.entry_name.replace(' ', '_')
+
     def __str__(self):
         return str(self.entry_ID)
 

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -738,6 +738,7 @@ function createCommPolygon() {
   // clean up polyFilter -- this is the array of GEOID to be stored
   polyFilter.splice(0, 1);
   polyFilter.splice(0, 1);
+  // TODO: add census blocks for dane county by matching municipal wards to blocks
   if (!dane_cty) {
     drawUsingBlocks ? document.getElementById("id_census_blocks").value = polyFilter : document.getElementById("id_block_groups").value = polyFilter;
   }

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -738,10 +738,10 @@ function createCommPolygon() {
   // clean up polyFilter -- this is the array of GEOID to be stored
   polyFilter.splice(0, 1);
   polyFilter.splice(0, 1);
-  // if (!dane_cty) {
-  //   drawUsingBlocks ? document.getElementById("id_census_blocks").value = polyFilter : document.getElementById("id_block_groups").value = polyFilter;
-  // }
-  // console.log(document.getElementById("id_block_groups").value)
+  if (!dane_cty) {
+    drawUsingBlocks ? document.getElementById("id_census_blocks").value = polyFilter : document.getElementById("id_block_groups").value = polyFilter;
+  }
+  console.log(document.getElementById("id_block_groups").value)
   // load in the Population
   var pop = sessionStorage.getItem("pop");
   document.getElementById("id_population").value = pop;

--- a/main/static/main/js/geo.js
+++ b/main/static/main/js/geo.js
@@ -711,6 +711,7 @@ function createCommPolygon() {
     layers: [state + "-census-shading-" + layer_suffix],
   });
   var multiPolySave;
+  var dane_cty_blocks = [];
   queryFeatures.forEach(function (feature) {
     // get properties, depending on the feature type
     if (drawUsingBlocks) {
@@ -719,6 +720,14 @@ function createCommPolygon() {
       featureProp = feature.properties[bg_id];
     }
     if (polyFilter.includes(featureProp)) {
+      // if dane county, add feature.properties.geoids to an array
+      if (dane_cty) {
+        geoids = feature.properties["GEOIDS"].replace(/'/g, '"');
+        geoids_array = JSON.parse(geoids);
+        for (i = 0; i < geoids_array.length; i++) {
+          dane_cty_blocks.push(parseInt(geoids_array[i]));
+        }
+      }
       if (multiPolySave === undefined) {
         multiPolySave = feature;
       } else {
@@ -738,12 +747,15 @@ function createCommPolygon() {
   // clean up polyFilter -- this is the array of GEOID to be stored
   polyFilter.splice(0, 1);
   polyFilter.splice(0, 1);
-  // TODO: add census blocks for dane county by matching municipal wards to blocks
+
+  // supply the list of block group or census block ids for addition/creation as manytomany in db
   if (!dane_cty) {
     drawUsingBlocks ? document.getElementById("id_census_blocks").value = polyFilter : document.getElementById("id_block_groups").value = polyFilter;
+  } else {
+    document.getElementById("id_census_blocks").value = dane_cty_blocks;
   }
-  console.log(document.getElementById("id_block_groups").value)
-  // load in the Population
+  // console.log(document.getElementById("id_census_blocks").value)
+  // load in the Population, if exists
   var pop = sessionStorage.getItem("pop");
   document.getElementById("id_population").value = pop;
   return true;

--- a/main/static/main/readme/README_csv.txt
+++ b/main/static/main/readme/README_csv.txt
@@ -1,0 +1,45 @@
+Thank you for using Representable!
+
+You have downloaded your community/communities as a CSV file. A Block Equivalency CSV file is a standardized format for displaying census geographies.
+It is compatible with other mapping softwares such as Maptitude for Redistricting, Dave's Redistricting App, and more.
+CSV files exported from Representable contain two columns: BLOCKID and DISTRICTID. The BLOCKID contains the FIPS code of a Census Block from the 2020 Census
+for all states other than Oklahoma and Illinois (which use 2010 FIPS codes). The DISTRICTID contains an ID which aligns to a community.
+
+When utilizing community maps for drawing districts, doing analysis, or any other use, we believe that it is imperative to consider
+the qualitative input a community author provides when filling out the survey flow of Representable. Communities are not just maps,
+but the interests and concerns that bind people together. Please consult the interests and concerns of the community while utilizing this COI map.
+For reference, the questions users are asked are repeated below, corresponding to the requisite sections of the community information when visualized on Representable.
+
+------------------------------------------------------------------------------------------------------------
+
+**CULTURAL OR HISTORICAL INTERESTS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - What are the cultural bonds in your community?
+  - If your community has a shared history, what is it?
+
+Examples of cultural or historical interests: Religious groups, ethnic groups, languages, age groups, immigration status, historic or arts districts, etc.
+
+**ECONOMIC OR ENVIRONMENTAL INTERESTS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - Where are residents employed?
+  - If there are environmental concerns in your community, what are they?
+
+Examples of economic or environmental interests: Tourism industry, agricultural workers, mining town, manufacturing center, polluted natural resource, unemployment problem, etc.
+
+**COMMUNITY ACTIVITIES AND SERVICES QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - Where do people in your community gather or socialize?
+  - How and where does your community access services (healthcare, transportation, educational services, etc.)?
+
+Examples of activities and services: Shopping areas, schools and universities, libraries, parks, lakes, rivers, places of worship, healthcare services, public transport, local nonprofit organizations, etc.
+
+**COMMUNITY NEEDS AND CONCERNS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - What should politicians and/or map drawers know about your community?
+  - What are the needs of your community?
+  - Is there anything else you want to tell us about your community?
+
+Examples of needs or concerns: Keep community in the same district or separate into multiple districts, shared policy concerns, need for a social service, relationship to other nearby communities, issues with current district lines
+
+
+Contact us with any questions or feedback at team@representable.org

--- a/main/static/main/readme/README_geojson.txt
+++ b/main/static/main/readme/README_geojson.txt
@@ -1,0 +1,57 @@
+Thank you for using Representable!
+
+You have downloaded your community/communities as a GeoJSON file. A GeoJSON file is a standardized format for displaying geographies.
+It is compatible with other mapping softwares such as Maptitude for Redistricting, Dave's Redistricting App, and more.
+GeoJSON files exported from Representable includes geometry and properties fields. The geometry field contains the coordinates for the community map.
+The properties field contains the following variables:
+ - entry_name: the name of the community
+ - cultural_interests: a response to the cultural or historical interests questions, repeated below
+ - economic_interests: a response to the economic or environmental interests questions, repeated below
+ - comm_activities: a response to the community activities and services questions, repeated below
+ - other_considerations: a response to the community needs and concerns questions, repeated below
+ - custom_response: a response to a custom question, if included in a community mapping drive
+ - population: the population of the community (not available in most states that use 2020 census geographies)
+ - block_group_ids: if the community is made of block groups, the Census FIPS codes of the units that comprise the community
+ - census_block_ids: if the community is made of census blocks, the Census FIPS codes of the units that comprise the community
+ - organization: the name of the organization on Representable, if submitted to one
+ - drive: the name of the community mapping drive, if submitted to one
+ - author_name: only visible if the author is downloading their own community, or the admin of a mapping drive is downloading a community submitted to said drive.
+ - address: only visible if the author is downloading their own community, or the admin of a mapping drive is downloading a community submitted to said drive.
+
+When utilizing community maps for drawing districts, doing analysis, or any other use, we believe that it is imperative to consider
+the qualitative input a community author provides when filling out the survey flow of Representable. Communities are not just maps,
+but the interests and concerns that bind people together.
+
+------------------------------------------------------------------------------------------------------------
+
+**CULTURAL OR HISTORICAL INTERESTS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - What are the cultural bonds in your community?
+  - If your community has a shared history, what is it?
+
+Examples of cultural or historical interests: Religious groups, ethnic groups, languages, age groups, immigration status, historic or arts districts, etc.
+
+**ECONOMIC OR ENVIRONMENTAL INTERESTS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - Where are residents employed?
+  - If there are environmental concerns in your community, what are they?
+
+Examples of economic or environmental interests: Tourism industry, agricultural workers, mining town, manufacturing center, polluted natural resource, unemployment problem, etc.
+
+**COMMUNITY ACTIVITIES AND SERVICES QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - Where do people in your community gather or socialize?
+  - How and where does your community access services (healthcare, transportation, educational services, etc.)?
+
+Examples of activities and services: Shopping areas, schools and universities, libraries, parks, lakes, rivers, places of worship, healthcare services, public transport, local nonprofit organizations, etc.
+
+**COMMUNITY NEEDS AND CONCERNS QUESTIONS + EXAMPLES**
+Use these questions to think more about how you would describe your community...
+  - What should politicians and/or map drawers know about your community?
+  - What are the needs of your community?
+  - Is there anything else you want to tell us about your community?
+
+Examples of needs or concerns: Keep community in the same district or separate into multiple districts, shared policy concerns, need for a social service, relationship to other nearby communities, issues with current district lines
+
+
+Contact us with any questions or feedback at team@representable.org

--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -47,10 +47,10 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
               </div>
               <div class="row justify-content-center">
                 {% if user.is_authenticated %}
-                <a id="map-geo-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.zip"></a>
-                <a id="map-csv-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.zip"></a>
-                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="{{state_name|replace_spaces}}_communities.zip">Export as GeoJSON</button>
-                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="{{state_name|replace_spaces}}_communities.zip">Export as CSV</button>
+                <a id="map-geo-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.geojson"></a>
+                <a id="map-csv-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.csv"></a>
+                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="{{state_name|replace_spaces}}_communities.geojson">Export as GeoJSON</button>
+                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="{{state_name|replace_spaces}}_communities.csv">Export as CSV</button>
                 {% else %}
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as GeoJSON</a>
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as CSV</a>

--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -47,10 +47,10 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
               </div>
               <div class="row justify-content-center">
                 {% if user.is_authenticated %}
-                <a id="map-geo-link" class="d-none" href="" download="communities.geojson"></a>
-                <a id="map-csv-link" class="d-none" href="" download="communities.csv"></a>
-                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="communities.geojson">Export as GeoJSON</button>
-                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="communities.csv">Export as CSV</button>
+                <a id="map-geo-link" class="d-none" href="" download="{{state_name}}_communities.geojson"></a>
+                <a id="map-csv-link" class="d-none" href="" download="{{state_name}}_communities.csv"></a>
+                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="{{state_name}}_communities.geojson">Export as GeoJSON</button>
+                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="{{state_name}}_communities.csv">Export as CSV</button>
                 {% else %}
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as GeoJSON</a>
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as CSV</a>

--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -47,10 +47,10 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
               </div>
               <div class="row justify-content-center">
                 {% if user.is_authenticated %}
-                <a id="map-geo-link" class="d-none" href="" download="{{state_name}}_communities.geojson"></a>
-                <a id="map-csv-link" class="d-none" href="" download="{{state_name}}_communities.csv"></a>
-                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="{{state_name}}_communities.geojson">Export as GeoJSON</button>
-                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="{{state_name}}_communities.csv">Export as CSV</button>
+                <a id="map-geo-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.zip"></a>
+                <a id="map-csv-link" class="d-none" href="" download="{{state_name|replace_spaces}}_communities.zip"></a>
+                <button id="map-export-geo-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/geo/','geo')" role="button" download="{{state_name|replace_spaces}}_communities.zip">Export as GeoJSON</button>
+                <button id="map-export-csv-btn" class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" onclick="exportCois('{{multi_export_link}}/csv/','csv')" role="button" download="{{state_name|replace_spaces}}_communities.zip">Export as CSV</button>
                 {% else %}
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as GeoJSON</a>
                 <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">Export as CSV</a>

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -53,8 +53,10 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
               </div>
               <div class="row justify-content-center">
                 {% if user.is_authenticated %}
-                  <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href={{multi_export_link}}/geo/ role="button" download="communities.geojson">{% trans "Export All as GeoJSON" %}</a>
-                  <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href={{multi_export_link}}/csv/ role="button" download="communities.csv">{% trans "Export All as CSV" %}</a>
+                  {% with export_name=organization|set_export_name:drive %}
+                  <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href={{multi_export_link}}/geo/ role="button" download="{{export_name}}_communities.geojson">{% trans "Export All as GeoJSON" %}</a>
+                  <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href={{multi_export_link}}/csv/ role="button" download="{{export_name}}_communities.csv">{% trans "Export All as CSV" %}</a>
+                  {% endwith %}
                 {% else %}
                   <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">{% trans "Export All as GeoJSON" %}</a>
                   <a class="mb-2 btn btn-outline-primary btn-canvas mx-auto d-none d-sm-block" href='{% url "account_login" %}?next={{request.path}}' role="button">{% trans "Export All as CSV" %}</a>

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -99,7 +99,7 @@
                       {% with link_text="/export/geojson/"|add:state|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
                         <a class="btn btn-primary w-50 w-md-75 w-xl-100 mb-3 mb-md-0" data-toggle="modal" href="#" data-target="#geojson-explain-modal" rel="nofollow" download>GeoJSON</a>
-                        <a href={{link_text}} download="{{c.human_readable_name}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
+                        <a href={{link_text}} download="{{c.human_readable_name}}.zip" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
                       </div>
                       <!-- ********************* -->
                       <div class="col-12 col-md-4">
@@ -108,14 +108,14 @@
                       {% endwith %}
                       {% with link_text="/export/csv/"|add:state|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
-                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.csv">CSV</a>
+                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.zip">CSV</a>
                       </div>
                       {% endwith %}
                     {% else %}
                       {% with link_text="/export/geojson/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
                         <a class="btn btn-primary w-50 w-md-75 w-xl-100 mb-3 mb-md-0" data-toggle="modal" data-target="#geojson-explain-modal" rel="nofollow" download>GeoJSON</a>
-                        <a href={{link_text}} download="{{c.human_readable_name}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
+                        <a href={{link_text}} download="{{c.human_readable_name}}.zip" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
                       </div>
                       <!-- ********************* -->
                       <div class="col-12 col-md-4">
@@ -124,7 +124,7 @@
                       {% endwith %}
                       {% with link_text="/export/csv"|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
-                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.csv">CSV</a>
+                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.zip">CSV</a>
                       </div>
                       {% endwith %}
                     {% endif %}

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -99,7 +99,7 @@
                       {% with link_text="/export/geojson/"|add:state|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
                         <a class="btn btn-primary w-50 w-md-75 w-xl-100 mb-3 mb-md-0" data-toggle="modal" href="#" data-target="#geojson-explain-modal" rel="nofollow" download>GeoJSON</a>
-                        <a href={{link_text}} download="community_{{c.entry_ID}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
+                        <a href={{link_text}} download="{{c.human_readable_name}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
                       </div>
                       <!-- ********************* -->
                       <div class="col-12 col-md-4">
@@ -108,14 +108,14 @@
                       {% endwith %}
                       {% with link_text="/export/csv/"|add:state|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
-                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="community_{{c.entry_ID}}.csv">CSV</a>
+                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.csv">CSV</a>
                       </div>
                       {% endwith %}
                     {% else %}
                       {% with link_text="/export/geojson/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
                         <a class="btn btn-primary w-50 w-md-75 w-xl-100 mb-3 mb-md-0" data-toggle="modal" data-target="#geojson-explain-modal" rel="nofollow" download>GeoJSON</a>
-                        <a href={{link_text}} download="community_{{c.entry_ID}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
+                        <a href={{link_text}} download="{{c.human_readable_name}}.geojson" id="hidden-download-geojson" class="hidden">Hidden Download GeoJSON</a>
                       </div>
                       <!-- ********************* -->
                       <div class="col-12 col-md-4">
@@ -124,7 +124,7 @@
                       {% endwith %}
                       {% with link_text="/export/csv"|add:"/?map_id="|addstr:c.entry_ID %}
                       <div class="col-12 col-md-4">
-                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="community_{{c.entry_ID}}.csv">CSV</a>
+                        <a class="btn btn-primary w-50 w-md-75 w-xl-100" href={{link_text}} role="button" download="{{c.human_readable_name}}.csv">CSV</a>
                       </div>
                       {% endwith %}
                     {% endif %}

--- a/main/templatetags/representable_extras.py
+++ b/main/templatetags/representable_extras.py
@@ -10,3 +10,11 @@ def addstr(arg1, arg2):
 @register.filter
 def get_item(value, key):
     return value[key]
+
+@register.filter
+def set_export_name(organization, drive):
+    """return drive if it exists"""
+    if drive:
+        return drive.replace(" ", "_")
+    else:
+        return organization.replace(" ", "_")

--- a/main/templatetags/representable_extras.py
+++ b/main/templatetags/representable_extras.py
@@ -18,3 +18,7 @@ def set_export_name(organization, drive):
         return drive.replace(" ", "_")
     else:
         return organization.replace(" ", "_")
+
+@register.filter
+def replace_spaces(arg1):
+    return arg1.replace(" ", "_")

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -559,7 +559,7 @@ class Submission(View):
         # THIS IS ALL FOR TESTING - TODO: DELETE
         gj = make_geojson(request, user_map)
         print("-----block groups in geojson------")
-        print(gj["properties"]["census_block_ids"])
+        # print(gj["properties"]["census_block_ids"])
         print("---data---")
         data = dict()
         if 'block_group_ids' in gj['properties']:
@@ -1392,13 +1392,18 @@ class MultiExportView(TemplateView):
                 geojson.dumps(final), content_type="application/json"
             )
         else:
-            print("********", "csv", "********")
+            print('********', 'csv', '********')
             dictform = json.loads(geojson.dumps(final))
             df = pd.DataFrame()
-            for entry in dictform["features"]:
-                row_dict = entry["properties"].copy()
-                row_dict["geometry"] = str(entry["geometry"])
-                df = df.append(row_dict, ignore_index=True)
-            response = HttpResponse(df.to_csv(), content_type="text/csv")
+            for i, entry in enumerate(dictform["features"]):
+                row_dict = dict()
+                if 'block_group_ids' in entry['properties']:
+                    row_dict['BLOCKID'] = entry['properties']['block_group_ids']
+                else:
+                    row_dict['BLOCKID'] = entry['properties']['census_block_ids']
+                row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
+                df = df.append(pd.DataFrame(row_dict))
+                print(df)
+            response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
 
         return response

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -840,7 +840,7 @@ class ExportView(TemplateView):
                 data['BLOCKID'] = gj['properties']['block_group_ids']
             else:
                 data['BLOCKID'] = gj['properties']['census_block_ids']
-            data['DISTRICT'] = [0] * len(data['BLOCKID'])
+            data['DISTRICT'] = [1] * len(data['BLOCKID'])
             comm_csv = pd.DataFrame(data).to_csv(index=False)
             response = HttpResponse(content_type='application/zip')
             with zipfile.ZipFile(response, "w") as z:
@@ -1409,7 +1409,7 @@ class MultiExportView(TemplateView):
                     row_dict['BLOCKID'] = entry['properties']['block_group_ids']
                 else:
                     row_dict['BLOCKID'] = entry['properties']['census_block_ids']
-                row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
+                row_dict['DISTRICT'] = [i + 1] * len(row_dict['BLOCKID'])
                 df = df.append(pd.DataFrame(row_dict))
             response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
             # response = HttpResponse(content_type='application/zip')

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -845,7 +845,7 @@ class ExportView(TemplateView):
             response = HttpResponse(content_type='application/zip')
             with zipfile.ZipFile(response, "w") as z:
                 z.writestr('%s.csv' % export_name, comm_csv)
-                z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
+                z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
             response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         else:
             # create a zip file that includes geojson + readme explaining the file format and including questions from survey page
@@ -853,7 +853,7 @@ class ExportView(TemplateView):
             with zipfile.ZipFile(response, "w") as z:
                 with z.open("%s.geojson" % export_name, "w") as c:
                     c.write(geojson.dumps(gj).encode("utf-8"))
-                z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
+                z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
             response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         return response
 
@@ -1387,16 +1387,18 @@ class MultiExportView(TemplateView):
 
         final = geojson.FeatureCollection(all_gj)
         export_name = state_obj.name.replace(" ", "_") + "_communities"
-        response = HttpResponse(content_type='application/zip')
 
         if kwargs["type"] == "geo":
             print("********", "geo", "********")
+            response = HttpResponse(
+                geojson.dumps(final), content_type="application/json"
+            )
             # create a zip file that includes geojson + readme explaining the file format and including questions from survey page
-            with zipfile.ZipFile(response, "w") as z:
-                with z.open("%s.geojson" % export_name, "w") as c:
-                    c.write(geojson.dumps(final).encode("utf-8"))
-                z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
-            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
+            # with zipfile.ZipFile(response, "w") as z:
+            #     with z.open("%s.geojson" % export_name, "w") as c:
+            #         c.write(geojson.dumps(final).encode("utf-8"))
+            #     z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
+            # response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         else:
             print('********', 'csv', '********')
             dictform = json.loads(geojson.dumps(final))
@@ -1409,10 +1411,10 @@ class MultiExportView(TemplateView):
                     row_dict['BLOCKID'] = entry['properties']['census_block_ids']
                 row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
                 df = df.append(pd.DataFrame(row_dict))
-            comm_csv = df.to_csv(index=False)
+            response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
             # response = HttpResponse(content_type='application/zip')
-            with zipfile.ZipFile(response, "w") as z:
-                z.writestr('%s.csv' % export_name, comm_csv)
-                z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
-            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
+            # with zipfile.ZipFile(response, "w") as z:
+            #     z.writestr('%s.csv' % export_name, comm_csv)
+            #     z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
+            # response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         return response

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -556,21 +556,6 @@ class Submission(View):
         # query will have length 1 or database is invalid
         user_map = query[0]
 
-        # THIS IS ALL FOR TESTING - TODO: DELETE
-        gj = make_geojson(request, user_map)
-        print("-----block groups in geojson------")
-        # print(gj["properties"]["census_block_ids"])
-        print("---data---")
-        data = dict()
-        if 'block_group_ids' in gj['properties']:
-            data['BLOCKID'] = gj['properties']['block_group_ids']
-        else:
-            data['BLOCKID'] = gj['properties']['census_block_ids']
-        data['DISTRICT'] = [0] * len(data['BLOCKID'])
-        print(data)
-        comm_csv = pd.DataFrame(data).to_csv(index=False)
-        print(comm_csv)
-
         if user_map.drive:
             folder_name = query[0].drive.slug
             # has_state = False
@@ -1403,7 +1388,6 @@ class MultiExportView(TemplateView):
                     row_dict['BLOCKID'] = entry['properties']['census_block_ids']
                 row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
                 df = df.append(pd.DataFrame(row_dict))
-                print(df)
             response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
 
         return response

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -20,6 +20,7 @@
 import asyncio
 import boto3
 import urllib
+import zipfile
 from urllib.request import urlopen
 from django.contrib import messages
 from django.http import (
@@ -95,6 +96,7 @@ from django.utils.translation import (
     get_language,
 )
 from django.urls import reverse, reverse_lazy
+from representable.settings.base import STATIC_ROOT
 
 # from django.utils.translation import (
 #     LANGUAGE_SESSION_KEY,
@@ -830,7 +832,7 @@ class ExportView(TemplateView):
 
         gj = make_geojson(request, query)
 
-        gs = geojson.dumps(gj)
+        export_name = query.entry_name.replace(" ", "_")
         if "csv" in request.path:
             # this is the new code -- turns geojson into csv for export
             data = dict()
@@ -840,9 +842,19 @@ class ExportView(TemplateView):
                 data['BLOCKID'] = gj['properties']['census_block_ids']
             data['DISTRICT'] = [0] * len(data['BLOCKID'])
             comm_csv = pd.DataFrame(data).to_csv(index=False)
-            response = HttpResponse(comm_csv, content_type="text/csv")
+            response = HttpResponse(content_type='application/zip')
+            with zipfile.ZipFile(response, "w") as z:
+                z.writestr('%s.csv' % export_name, comm_csv)
+                z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
+            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         else:
-            response = HttpResponse(gs, content_type="application/json")
+            # create a zip file that includes geojson + readme explaining the file format and including questions from survey page
+            response = HttpResponse(content_type='application/zip')
+            with zipfile.ZipFile(response, "w") as z:
+                with z.open("%s.geojson" % export_name, "w") as c:
+                    c.write(geojson.dumps(gj).encode("utf-8"))
+                z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
+            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         return response
 
 
@@ -892,6 +904,9 @@ class Map(TemplateView):
             # at this point all the elements of the array are coordinates of the polygons
             struct = geojson.loads(s)
             entryPolyDict[obj.entry_ID] = struct.coordinates
+
+            export_name = state_obj.name.replace(" ", "_") + "_communities"
+            print(export_name)
 
         context = {
             "state": state,
@@ -1371,11 +1386,17 @@ class MultiExportView(TemplateView):
             all_gj.append(gj)
 
         final = geojson.FeatureCollection(all_gj)
+        export_name = state_obj.name.replace(" ", "_") + "_communities"
+        response = HttpResponse(content_type='application/zip')
+
         if kwargs["type"] == "geo":
             print("********", "geo", "********")
-            response = HttpResponse(
-                geojson.dumps(final), content_type="application/json"
-            )
+            # create a zip file that includes geojson + readme explaining the file format and including questions from survey page
+            with zipfile.ZipFile(response, "w") as z:
+                with z.open("%s.geojson" % export_name, "w") as c:
+                    c.write(geojson.dumps(final).encode("utf-8"))
+                z.write(STATIC_ROOT + '/main/readme/README_geojson.txt', arcname="README_geojson.txt")
+            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         else:
             print('********', 'csv', '********')
             dictform = json.loads(geojson.dumps(final))
@@ -1388,6 +1409,10 @@ class MultiExportView(TemplateView):
                     row_dict['BLOCKID'] = entry['properties']['census_block_ids']
                 row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
                 df = df.append(pd.DataFrame(row_dict))
-            response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
-
+            comm_csv = df.to_csv(index=False)
+            # response = HttpResponse(content_type='application/zip')
+            with zipfile.ZipFile(response, "w") as z:
+                z.writestr('%s.csv' % export_name, comm_csv)
+                z.write(STATIC_ROOT + '/main/readme/README_csv.txt', arcname="README_csv.txt")
+            response['Content-Disposition'] = 'attachment; filename=%s.zip' % export_name
         return response

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -294,11 +294,16 @@ class MultiExportView(TemplateView):
             print('********', 'csv', '********')
             dictform = json.loads(geojson.dumps(final))
             df = pandas.DataFrame()
-            for entry in dictform['features']:
-                row_dict = entry['properties'].copy()
-                row_dict['geometry'] = str(entry['geometry'])
-                df = df.append(row_dict, ignore_index=True)
-            response = HttpResponse(df.to_csv(), content_type="text/csv")
+            for i, entry in enumerate(dictform["features"]):
+                row_dict = dict()
+                if 'block_group_ids' in entry['properties']:
+                    row_dict['BLOCKID'] = entry['properties']['block_group_ids']
+                else:
+                    row_dict['BLOCKID'] = entry['properties']['census_block_ids']
+                row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
+                df = df.append(pandas.DataFrame(row_dict))
+                print(df)
+            response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
 
         return response
 

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -302,7 +302,6 @@ class MultiExportView(TemplateView):
                     row_dict['BLOCKID'] = entry['properties']['census_block_ids']
                 row_dict['DISTRICT'] = [i] * len(row_dict['BLOCKID'])
                 df = df.append(pandas.DataFrame(row_dict))
-                print(df)
             response = HttpResponse(df.to_csv(index=False), content_type="text/csv")
 
         return response


### PR DESCRIPTION
**changes**
- switches export of individual communities to a zip file with the original file type (geojson or csv) and a readme (due to a bug it isn't possible at the moment to do the same for the multiexport -- working on that)
- updated storing of census block and block group manytomany field when saving a community to work properly
- updates csv file to match block equivalency format : includes BLOCKID (census FIPS code) and DISTRICT (0 for single community, counts up for multiple)
- changes the name of exported files to match more closely with the context of what's being exported: the name of the community for single export, and the name of the state/drive/org for multi export
- update municipal wards redistricting export in wisconsin to export census block ids rather than municipal wards FIPS codes

**to test**
- python manage.py collectstatic
- python manage.py runserver
- draw a community
- export community as geojson and csv, check that file looks as expected
- export multiple communities in state/drive, check that files look as expected
- draw community for municipal wards drive: http://127.0.0.1:8000/drive/tell-us-about-your/
- export community, and check that BLOCKID column in CSV has 15 characters, representing a census block
- for each of these exports, check that the name matches as expected and described above, and if necessary test with other mapping software for import capability