### PR TITLE
Add survey questions as context to submission page

### DIFF
--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -102,8 +102,8 @@
                           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                           </button>
-                          <h4 class="mx-md-5 px-md-5 mt-md-5"><strong>Your Community Information</strong></h4>
-                          <p class="mx-md-5 px-md-5">When drawing a map with Representable, you are asked a series of questions in different categories. We've repeated the questions below.</p>
+                          <h4 class="mx-lg-5 px-lg-5 mt-md-5"><strong>Your Community Information</strong></h4>
+                          <p class="mx-lg-5 px-lg-5">When drawing a map with Representable, you are asked a series of questions in different categories. We've repeated the questions below.</p>
                           <!-- Sections: -->
                           <!-- Activities -->
                           <div class="accordion" id="comm_activities_accordion">

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -102,8 +102,8 @@
                           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                           </button>
-                          <h4 class="mx-lg-5 px-lg-5 mt-md-5"><strong>Your Community Information</strong></h4>
-                          <p class="mx-lg-5 px-lg-5">When drawing a map with Representable, you are asked a series of questions in different categories. We've repeated the questions below.</p>
+                          <h4 class="mx-lg-5 px-lg-5 mt-md-5"><strong>{% trans "Your Community Information" %}</strong></h4>
+                          <p class="mx-lg-5 px-lg-5">{% trans "When drawing a map with Representable, you are asked a series of questions in different categories. We've repeated the questions below." %}</p>
                           <!-- Sections: -->
                           <!-- Activities -->
                           <div class="accordion" id="comm_activities_accordion">
@@ -118,7 +118,7 @@
                                     <span class="blue-text"><b>{% trans "Examples of activities and services:" %}</b> {% trans "Shopping areas, schools and universities, libraries, parks, lakes, rivers, places of worship, healthcare services, public transport, local nonprofit organizations, etc." %}</span>
                                   </p>
                                   {% if c.comm_activities %}
-                                    <p class="collapse-in ml-4"><b>Your response:</b> {{c.comm_activities}}</p>
+                                    <p class="collapse-in ml-4"><b>{% trans "Your response: " %}</b> {{c.comm_activities}}</p>
                                   {% endif %}
                               </div>
 

--- a/main/templates/main/submission.html
+++ b/main/templates/main/submission.html
@@ -94,6 +94,106 @@
                     </div>
                   </div>
                   <!-- ********************* -->
+                  <!-- Community info modal -->
+                  <div class="modal fade blue-modal" id="submission-info-modal" tabindex="-1" role="dialog" aria-labelledby="submission-info-modalLabel" aria-hidden="true">
+                    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+                      <div class="modal-content">
+                        <div class="modal-body px-md-5 text-left">
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                          <h4 class="mx-md-5 px-md-5 mt-md-5"><strong>Your Community Information</strong></h4>
+                          <p class="mx-md-5 px-md-5">When drawing a map with Representable, you are asked a series of questions in different categories. We've repeated the questions below.</p>
+                          <!-- Sections: -->
+                          <!-- Activities -->
+                          <div class="accordion" id="comm_activities_accordion">
+                              <button id="comm_activities_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#comm_activities_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                                  <h5 class="survey-sect-title">{% trans "Community Activities and Services" %}<i class="fas fa-angle-down pl-3"></i></h5>
+                              </button>
+                              <div id="comm_activities_example" class="collapse" aria-labelledby="comm_activities_accordion" data-parent="#comm_activities_accordion">
+                                  <p class="collapse-in ml-4 gray-text">
+                                    <b>{% trans "Use these questions to think more about how you would describe your community..." %}</b><br>
+                                    &emsp; - {% trans "Where do people in your community gather or socialize?" %} <br>
+                                    &emsp; - {% trans "How and where does your community access services (healthcare, transportation, educational services, etc.)?" %}<br><br>
+                                    <span class="blue-text"><b>{% trans "Examples of activities and services:" %}</b> {% trans "Shopping areas, schools and universities, libraries, parks, lakes, rivers, places of worship, healthcare services, public transport, local nonprofit organizations, etc." %}</span>
+                                  </p>
+                                  {% if c.comm_activities %}
+                                    <p class="collapse-in ml-4"><b>Your response:</b> {{c.comm_activities}}</p>
+                                  {% endif %}
+                              </div>
+
+                          </div>
+
+                          <!-- Cultural -->
+                          <div class="accordion" id="cultural_interests_accordion">
+                              <button id="cultural_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#cultural_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                                  <h5 class="survey-sect-title">{% trans "Cultural or Historical Interests" %}<i class="fas fa-angle-down pl-3"></i></h5>
+                              </button>
+                              <div id="cultural_interests_example" class="collapse" aria-labelledby="cultural_interests_accordion" data-parent="#cultural_interests_accordion">
+                                <p class="collapse-in ml-4 gray-text">
+                                  <b>{% trans "Use these questions to think more about how you would describe your community..." %}</b><br>
+                                  &emsp; - {% trans "What are the cultural bonds in your community?" %} <br>
+                                  &emsp; - {% trans "If your community has a shared history, what is it?" %}<br><br>
+                                  <span class="blue-text"><b>{% trans "Examples of cultural or historical interests: " %}</b>{% trans "Religious groups, ethnic groups, languages, age groups, immigration status, historic or arts districts, etc."%} </span>
+                                </p>
+                                {% if c.cultural_interests %}
+                                  <p class="collapse-in ml-4"><b>{% trans "Your response: " %}</b> {{c.cultural_interests}}</p>
+                                {% endif %}
+                              </div>
+                          </div>
+                          <!--  Economic -->
+                          <div class="accordion" id="economic_interests_accordion">
+                              <button id="economic_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#economic_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                                  <h5 class="survey-sect-title">{% trans "Economic or Environmental Interests" %}<i class="fas fa-angle-down pl-3"></i></h5>
+                              </button>
+                              <div id="economic_interests_example" class="collapse" aria-labelledby="economic_interests_accordion" data-parent="#economic_interests_accordion">
+                                  <p class="collapse-in ml-4 gray-text">
+                                      {% blocktrans trimmed %}
+                                      <b>Use these questions to think more about how you would describe your community...</b><br>
+                                      &emsp; - Where are residents employed?<br>
+                                      &emsp; - If there are environmental concerns in your community, what are they?<br><br>
+                                      <span class="blue-text"><b>Examples of economic or environmental interests:</b> Tourism industry, agricultural workers, mining town, manufacturing center, polluted natural resource, unemployment problem, etc.</span>
+                                      {% endblocktrans %}
+                                  </p>
+                                  {% if c.economic_interests %}
+                                    <p class="collapse-in ml-4"><b>{% trans "Your response: " %}</b> {{c.economic_interests}}</p>
+                                  {% endif %}
+                              </div>
+                          </div>
+
+                          <!-- Other -->
+                          <div class="accordion" id="other_interests_accordion">
+                              <button id="other_interests_btn" class="btn btn-link text-left pl-0 no-underline-link" type="button" data-target="#other_interests_example" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
+                                  <h5 class="survey-sect-title">{% trans "Community Needs and Concerns" %}<i class="fas fa-angle-down pl-3"></i></h5>
+                              </button>
+                              <div id="other_interests_example" class="collapse" aria-labelledby="other_interests_accordion" data-parent="#other_interests_accordion">
+                                <p class="collapse-in ml-4 gray-text">
+                                  <b>{% trans "Use these questions to think more about how you would describe your community..." %}</b><br>
+                                  &emsp; - {% trans "What should politicians and/or map drawers know about your community?" %}<br>
+                                  &emsp; - {% trans "What are the needs of your community?" %}<br>
+                                  &emsp; - {% trans "Is there anything else you want to tell us about your community?" %}<br><br>
+                                  <span class="blue-text"><b>{% trans "Examples of needs or concerns: " %}</b>{% trans "Keep community in the same district or separate into multiple districts, shared policy concerns, need for a social service, relationship to other nearby communities, issues with current district lines" %}</span>
+                                </p>
+                                {% if c.other_considerations %}
+                                  <p class="collapse-in ml-4"><b>{% trans "Your response: " %}</b> {{c.other_considerations}}</p>
+                                {% endif %}
+                              </div>
+                          </div>
+
+                          <!-- custom question -->
+                          {% if c.drive and c.drive.custom_question %}
+                            <p class="my-4 ml-1 gray-text">
+                              <b>{{ c.drive.custom_question }}</b><br>
+                            </p>
+                            {% if c.custom_response %}
+                              <p class="collapse-in ml-4"><b>{% trans "Your response: " %}</b> {{c.custom_response}}</p>
+                            {% endif %}
+                          {% endif %}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- ********************* -->
                   <div class="row">
                     {% if has_state %}
                       {% with link_text="/export/geojson/"|add:state|add:"/?map_id="|addstr:c.entry_ID %}
@@ -141,7 +241,7 @@
         </div>
         <div class="card text-left border-0 w-100 rounded-lg mt-3">
           <div class="card-body">
-            <h4 class="card-title header-text"><strong>{% trans "Community Information" %}</strong></h4>
+            <h4 class="card-title header-text"><strong>{% trans "Community Information" %}</strong> <button class="btn btn-link no-underline-link p-0" type="button" data-toggle="modal" data-target="#submission-info-modal" rel="nofollow"><i class="far fa-question-circle small text-muted"></i></a></h4>
             <div class="accordion map-info-item mt-4" id="mobile-map-activities-accordion">
                 <button class="btn btn-link text-left comm-item-text pl-3 no-underline-link" type="button" data-target="#mobile-map-activities-resp" aria-expanded="false" aria-controls="collapseOne" onclick="toggleAngle(this)">
                     {% trans "Community Activities and Services" %}<i class="fas fa-angle-down pl-3 pr-5 pt-2 pb-2"></i>


### PR DESCRIPTION
**changes**
- adds question mark next to "Community Information" for more context
- button triggers a modal that repeats the survey questions + includes the response of the community, if there is one
- adds a few lines that will need to be translated, but the questions and the examples remain translated as they do on the survey page

**screenshots**
![image](https://user-images.githubusercontent.com/41943646/123823758-1952a100-d8c3-11eb-876a-38056e5ac0d7.png)
![image](https://user-images.githubusercontent.com/41943646/123823819-22dc0900-d8c3-11eb-8c2e-d1128331b98e.png)
