### PR TITLE
django admin update

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -36,6 +36,7 @@ import csv
 from .models import State, Drive, Organization
 
 # ********************************************************************* #
+
 class ExportCsvMixin:
     def export_as_csv(self, request, queryset):
 
@@ -54,6 +55,7 @@ class ExportCsvMixin:
 
     export_as_csv.short_description = "Export Selected"
 
+# ********************************************************************* #
 
 class StateAdminForm(forms.ModelForm):
     content_news = forms.CharField(widget=CKEditorWidget())
@@ -192,11 +194,13 @@ class CommunityAdmin(ImportExportModelAdmin):
         'get_economic_length',
         'get_cultural_length',
         'get_needs_length',
+        'get_tags',
     )
     list_filter = (
         "drive",
         "organization",
         "state",
+        "tags"
     )
 
     def export_emails_as_csv(self, request, queryset):
@@ -218,7 +222,6 @@ class CommunityAdmin(ImportExportModelAdmin):
     def get_user_email(self, obj):
         return obj.user.email
     get_user_email.short_description = 'user email'
-    get_user_email.admin_order_field = 'user_email'
     def get_services_length(self, obj):
         return len(obj.comm_activities)
     get_services_length.short_description = 'services length'
@@ -235,6 +238,13 @@ class CommunityAdmin(ImportExportModelAdmin):
         return len(obj.other_considerations)
     get_needs_length.short_description = 'needs length'
     get_needs_length.admin_order_field = 'length_needs'
+    def get_tags(self, obj):
+        tags = []
+        for tag in obj.tags.all():
+            tags.append(str(tag))
+        return ', '.join(tags)
+    get_tags.short_description = 'tags'
+
 
     resource_class = CommunityResource
 

--- a/main/admin.py
+++ b/main/admin.py
@@ -182,6 +182,7 @@ class CommunityAdmin(ImportExportModelAdmin):
     list_display = (
         "id",
         "user_name",
+        "get_user_email",
         "entry_name",
         "organization",
         "drive",
@@ -198,6 +199,26 @@ class CommunityAdmin(ImportExportModelAdmin):
         "state",
     )
 
+    def export_emails_as_csv(self, request, queryset):
+
+        meta = self.model._meta
+
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+        writer = csv.writer(response)
+
+        for obj in queryset:
+            row = writer.writerow([obj.user.email])
+
+        return response
+
+    export_emails_as_csv.short_description = "Export Selected Emails"
+    actions = ["export_emails_as_csv"]
+
+    def get_user_email(self, obj):
+        return obj.user.email
+    get_user_email.short_description = 'user email'
+    get_user_email.admin_order_field = 'user_email'
     def get_services_length(self, obj):
         return len(obj.comm_activities)
     get_services_length.short_description = 'services length'


### PR DESCRIPTION
**changes**
- adds more information to organization tab on django admin
- adds dates of community entries to filter by (ex: how many communities were drawn in june 2021)
- allows filtering by state for each entry
- adds more information to drive tab on django admin
- adds ability to export a csv of organizations and drives
- adds ability to export a csv of user email addresses (can filter by org/drive first)
- adds tags and filtering by tags to community entry in django admin

**to test**
- python manage.py runserver
- navigate to http://127.0.0.1:8000/admin/
- check organization, communityentry, and drive views
- check all expected values are there as expected
- check all filtering works as expected with no errors
- check that all exporting works as expected with no errors