### PR TITLE
variable opacity on map pages

### DIFF
--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -156,6 +156,18 @@ map.on("load", function () {
     });
   }
 
+  var layers = map.getStyle().layers;
+  // Find the index of the first symbol layer in the map style
+  // this is so that added layers go under the symbols on the map
+  var firstSymbolId = layers[0].id;
+  for (var i = 0; i < layers.length; i++) {
+    console.log(layers[i]["source-layer"]);
+    if (layers[i].type === "symbol") {
+      firstSymbolId = layers[i].id;
+      break;
+    }
+  }
+
   // mxzoom(def 18 higher = more detail)
   // tol(def .375 higher = simpler geometry)
 
@@ -167,7 +179,8 @@ map.on("load", function () {
   });
   console.log(coidata_geojson_format);
 
-  map.addLayer({
+  map.addLayer(
+    {
       'id': 'coi_layer_fill',
       'type': 'fill',
       'source': 'coi_all',
@@ -175,7 +188,9 @@ map.on("load", function () {
           'fill-color': 'rgb(110, 178, 181)',
           'fill-opacity': 0.15
       },
-  });
+    },
+    firstSymbolId
+  );
   map.addLayer({
     id: "coi_line",
     type: "line",
@@ -264,6 +279,10 @@ map.on("load", function () {
       essential: true // this animation is considered essential with respect to prefers-reduced-motion
     });
   }
+});
+
+map.on("style.load", function () {
+
 });
 
 // on click, zoom to community

--- a/main/static/main/js/map.js
+++ b/main/static/main/js/map.js
@@ -113,6 +113,8 @@ map.on("load", function () {
   addAllLayers(map, document, "map");
   // draw all coi's in one layer
   coidata = JSON.parse(coidata.replace(/'/g, '"'));
+  numBG = JSON.parse(numBG.replace(/'/g, '"'));
+  numBlock = JSON.parse(numBlock.replace(/'/g, '"'));
 
   coidata_geojson_format = {
     'type': 'FeatureCollection',
@@ -128,7 +130,7 @@ map.on("load", function () {
       featureType = "MultiPolygon";
       temp = [];
       final[0] = [coidata[coi_id][0][0]];
-      if (coidata[coi_id][1][0].length > 2) {
+      if (coidata[coi_id][1] && coidata[coi_id][1][0].length > 2) {
         final[1] = [coidata[coi_id][1][0]];
       }
     } else if (coidata[coi_id][0].length > 2) {
@@ -142,7 +144,16 @@ map.on("load", function () {
     var fit = new L.Polygon(final).getBounds();
     var southWest = new mapboxgl.LngLat(fit['_southWest']['lat'], fit['_southWest']['lng']);
     var northEast = new mapboxgl.LngLat(fit['_northEast']['lat'], fit['_northEast']['lng']);
-    community_bounds[coi_id] = new mapboxgl.LngLatBounds(southWest, northEast)
+    community_bounds[coi_id] = new mapboxgl.LngLatBounds(southWest, northEast);
+
+    // get value for block and block group
+    var coi_op = 0.15;
+    if (comms_counter >= 25) {
+      coi_op = 0.12;
+      if (numBlock[coi_id] > 300 || numBG[coi_id] > 15) coi_op = 0.08;
+      if (numBlock[coi_id] > 600 || numBG[coi_id] > 50) coi_op = 0.05;
+      if (numBlock[coi_id] > 900 || numBG[coi_id] > 100) coi_op = 0.025;
+    }
 
     coidata_geojson_format.features.push({
       'type': 'Feature',
@@ -152,6 +163,7 @@ map.on("load", function () {
       },
       'properties': {
           'id': coi_id,
+          'coi_op': coi_op,
       },
     });
   }
@@ -161,7 +173,6 @@ map.on("load", function () {
   // this is so that added layers go under the symbols on the map
   var firstSymbolId = layers[0].id;
   for (var i = 0; i < layers.length; i++) {
-    console.log(layers[i]["source-layer"]);
     if (layers[i].type === "symbol") {
       firstSymbolId = layers[i].id;
       break;
@@ -177,7 +188,6 @@ map.on("load", function () {
       'maxzoom': mxzoom,
       'tolerance': tol
   });
-  console.log(coidata_geojson_format);
 
   map.addLayer(
     {
@@ -186,7 +196,7 @@ map.on("load", function () {
       'source': 'coi_all',
       'paint': {
           'fill-color': 'rgb(110, 178, 181)',
-          'fill-opacity': 0.15
+          'fill-opacity': ['get', 'coi_op'],
       },
     },
     firstSymbolId
@@ -205,8 +215,6 @@ map.on("load", function () {
       "line-width": 2,
     },
   });
-
-  // console.log('finsihed layers');
 
   // hover to highlight
   $(".community-review-span").hover(function() {

--- a/main/templates/main/map.html
+++ b/main/templates/main/map.html
@@ -33,10 +33,13 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
     <div>
       <script type="text/javascript">
         var coidata = '{{ entries | escapejs }}';
+        var numBlock = '{{ numBlock | escapejs }}';
+        var numBG = '{{ numBG | escapejs }}';
         var mapbox_user_name = "{{mapbox_user_name}}";
         var state = "{{state}}";
         var centerLat = '{{ centerLat }}';
         var centerLng = '{{ centerLng }}';
+        var comms_counter = '{{comms_counter}}';
       </script>
     </div>
     <div class="col-md-4 col-wide">

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -35,6 +35,9 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
         var coidata = '{{ entries | escapejs }}';
         var state = '{{ state }}'
         var mapbox_user_name = "{{mapbox_user_name}}";
+        var numBlock = '{{ numBlock | escapejs }}';
+        var numBG = '{{ numBG | escapejs }}';
+        var comms_counter = '{{comms_counter}}';
       </script>
     </div>
     <div class="col-md-4 col-wide">

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -884,6 +884,9 @@ class Map(TemplateView):
 
         # the polygon coordinates
         entryPolyDict = dict()
+        # the size of each polygon in number of block groups or census blocks
+        numBlock = dict()
+        numBG = dict()
         try:
             state_obj = State.objects.get(abbr=state.upper())
         except:
@@ -918,6 +921,9 @@ class Map(TemplateView):
             struct = geojson.loads(s)
             entryPolyDict[obj.entry_ID] = struct.coordinates
 
+            numBG[obj.entry_ID] = len(obj.block_groups.all())
+            numBlock[obj.entry_ID] = len(obj.census_blocks.all())
+
             export_name = state_obj.name.replace(" ", "_") + "_communities"
 
         comms_counter = query.filter(admin_approved=True, private=False).count()
@@ -929,6 +935,8 @@ class Map(TemplateView):
             "comms_counter": comms_counter,
             "drives": drives,
             "entries": json.dumps(entryPolyDict),
+            "numBlock": numBlock,
+            "numBG": numBG,
             "mapbox_key": os.environ.get("DISTR_MAPBOX_KEY"),
             "mapbox_user_name": os.environ.get("MAPBOX_USER_NAME"),
         }

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -66,6 +66,9 @@ class PartnerMap(TemplateView):
 
         # the polygon coordinates
         entryPolyDict = dict()
+        # the size of each polygon in number of block groups or census blocks
+        numBlock = dict()
+        numBG = dict()
 
         # get the org to which this map belongs
         try:
@@ -118,6 +121,10 @@ class PartnerMap(TemplateView):
 
             struct = geojson.loads(s)
             entryPolyDict[obj.entry_ID] = struct.coordinates
+
+            numBG[obj.entry_ID] = len(obj.block_groups.all())
+            numBlock[obj.entry_ID] = len(obj.census_blocks.all())
+
             if is_admin:
                 for a in Address.objects.filter(entry=obj):
                     streets[obj.entry_ID] = a.street
@@ -139,6 +146,8 @@ class PartnerMap(TemplateView):
             "communities": query,
             "comms_counter": comms_counter,
             "entries": json.dumps(entryPolyDict),
+            "numBlock": numBlock,
+            "numBG": numBG,
             "mapbox_key": os.environ.get("DISTR_MAPBOX_KEY"),
             "mapbox_user_name": os.environ.get("MAPBOX_USER_NAME"),
         }


### PR DESCRIPTION
**changes**
- updates visualizations so that place names appear above cois
- for map pages with 25+ cois, adds a variable opacity system, depending on the number of blocks or block groups that comprise a community

**screenshots**
before:
![image](https://user-images.githubusercontent.com/41943646/132962163-05b562f0-b02b-4e8c-86eb-be367c1293f8.png)
after:
![image](https://user-images.githubusercontent.com/41943646/132962170-86e1b791-1bfd-44ba-93d9-6b868b92f361.png)
