### PR TITLE
remove address from map pages, add entry id to export

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -79,11 +79,11 @@ def make_geojson_for_state_map_page(request, entry):
         gj["features"][0]["properties"]["drive"] = user_map.drive.name
 
     gj["features"][0]["properties"]["author_name"] = user_map.user_name
-    for a in Address.objects.filter(entry=user_map):
-        addy = (
-            a.street + " " + a.city + ", " + a.state + " " + a.zipcode
-        )
-        gj["features"][0]["properties"]["address"] = addy
+    # for a in Address.objects.filter(entry=user_map):
+    #     addy = (
+    #         a.street + " " + a.city + ", " + a.state + " " + a.zipcode
+    #     )
+    #     gj["features"][0]["properties"]["address"] = addy
 
     feature = gj["features"][0]
     return feature
@@ -308,7 +308,7 @@ class CommunityAdmin(ImportExportModelAdmin):
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
         writer = csv.writer(response)
-        writer.writerow(["ENTRY NAME", "DISTRICT", "AUTHOR NAME", "ADDRESS", "CULTURAL AND HISTORICAL INTERESTS",
+        writer.writerow(["ENTRY NAME", "ENTRY ID", "DISTRICT", "AUTHOR NAME", "ADDRESS", "CULTURAL AND HISTORICAL INTERESTS",
         "ECONOMIC OR ENVIRONMENTAL INTERESTS", "COMMUNITY ACTIVITIES AND SERVICES", "COMMUNITY NEEDS AND CONCERNS",
         "RESPONSE TO CUSTOM DRIVE QUESTION", "POPULATION"])
 
@@ -320,7 +320,7 @@ class CommunityAdmin(ImportExportModelAdmin):
                 addy = (
                     a.street + " " + a.city + ", " + a.state + " " + a.zipcode
                 )
-            row = writer.writerow([obj.entry_name, i, name, addy, obj.cultural_interests, obj.economic_interests, obj.comm_activities, obj.other_considerations, obj.custom_response, obj.population])
+            row = writer.writerow([obj.entry_name, obj.entry_ID, i, name, addy, obj.cultural_interests, obj.economic_interests, obj.comm_activities, obj.other_considerations, obj.custom_response, obj.population])
 
         return response
 

--- a/main/templates/main/partners/map.html
+++ b/main/templates/main/partners/map.html
@@ -138,12 +138,7 @@ integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLP
                           <span class="small text-muted">
                           {% if is_org_admin %}
                             {{ c.user_name }}
-                            {% if streets|get_item:c.entry_ID %}
-                            | {{streets|get_item:c.entry_ID}},
-                            {{cities|get_item:c.entry_ID}} <br>
-                            {% else %}
                             <br>
-                            {% endif %}
                           {% endif %}
                           <a tabindex="0" class="small float-right mt-2" style="color:red" id="report" data-community-id={{c.id}} role="button" data-toggle="modal" data-target="#sendReport"> <span class="sr-only">Danger: </span>REPORT</a>
                           </span>

--- a/main/views/main.py
+++ b/main/views/main.py
@@ -730,6 +730,7 @@ def make_geojson(request, entry):
         geometry_field="census_blocks_polygon",
         fields=(
             "entry_name",
+            "entry_ID",
             "cultural_interests",
             "economic_interests",
             "comm_activities",
@@ -782,6 +783,7 @@ def make_geojson_for_state_map_page(request, entry):
         geometry_field="census_blocks_polygon",
         fields=(
             "entry_name",
+            "entry_ID",
             "cultural_interests",
             "economic_interests",
             "comm_activities",
@@ -1012,6 +1014,7 @@ def make_geojson_for_s3(entry):
         geometry_field="census_blocks_polygon",
         fields=(
             "entry_name",
+            "entry_ID",
             "cultural_interests",
             "economic_interests",
             "comm_activities",

--- a/main/views/partners.py
+++ b/main/views/partners.py
@@ -125,12 +125,12 @@ class PartnerMap(TemplateView):
             numBG[obj.entry_ID] = len(obj.block_groups.all())
             numBlock[obj.entry_ID] = len(obj.census_blocks.all())
 
-            if is_admin:
-                for a in Address.objects.filter(entry=obj):
-                    streets[obj.entry_ID] = a.street
-                    cities[obj.entry_ID] = (
-                        a.city + ", " + a.state + " " + a.zipcode
-                    )
+            # if is_admin:
+            #     for a in Address.objects.filter(entry=obj):
+            #         streets[obj.entry_ID] = a.street
+            #         cities[obj.entry_ID] = (
+            #             a.city + ", " + a.state + " " + a.zipcode
+            #         )
 
         if (self.request.user.is_authenticated and self.request.user.is_org_admin(org.id)):
             comms_counter = query.count()


### PR DESCRIPTION
**changes**
- removes showing and querying addresses for drive and org map pages
- adds entry_ID to export functions, so that entries can be consistently matched with testimony

**to test**
- go to drive map page
- check no errors, addresses don't show up
- export as geojson
- check that entry_ID is included
- go to django admin
- export community testimony
- check that entry_ID is included, and so is address